### PR TITLE
ofac: Add file downloader for OFAC files

### DIFF
--- a/download.go
+++ b/download.go
@@ -1,0 +1,91 @@
+// Copyright 2018 The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package ofac
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+var (
+	ofacFilenames = []string{
+		"add.csv",          // Address
+		"alt.csv",          // Alternate ID
+		"sdn.csv",          // Specially Designated National
+		"sdn_comments.csv", // Specially Designated National Comments
+	}
+	ofacUrlTemplate = "https://www.treasury.gov/ofac/downloads/%s"
+)
+
+func init() {
+	if v := os.Getenv("OFAC_DOWNLOAD_TEMPLATE"); v != "" {
+		ofacUrlTemplate = v
+	}
+}
+
+// ofacDownloader will download and cache OFAC files in a temp directory.
+//
+// If HTTP is nil then http.DefaultClient will be used (which has NO timeouts).
+//
+// See: https://www.treasury.gov/resource-center/sanctions/SDN-List/Pages/sdn_data.aspx
+type ofacDownloader struct {
+	HTTP *http.Client
+}
+
+// getFiles will download all OFAC related files and store them in a temporary directory
+// returned and an error otherwise.
+//
+// Callers are expected to cleanup the temp directory.
+func (dl *ofacDownloader) getFiles() (string, error) {
+	if dl.HTTP == nil {
+		dl.HTTP = http.DefaultClient
+	}
+
+	dir, err := ioutil.TempDir("", "ofac-downloader")
+	if err != nil {
+		return "", fmt.Errorf("OFAC: unable to make temp dir: %v", err)
+	}
+
+	wg := sync.WaitGroup{}
+	wg.Add(len(ofacFilenames))
+
+	for i := range ofacFilenames {
+		name := ofacFilenames[i]
+
+		go func(wg *sync.WaitGroup, filename string) {
+			defer wg.Done()
+
+			resp, err := dl.HTTP.Get(fmt.Sprintf(ofacUrlTemplate, filename))
+			if err != nil {
+				return
+			}
+			defer resp.Body.Close()
+
+			// Copy resp.Body into a file in our temp dir
+			fd, err := os.Create(filepath.Join(dir, filename))
+			if err != nil {
+				return
+			}
+			defer fd.Close()
+
+			io.Copy(fd, resp.Body) // copy contents
+		}(&wg, name)
+	}
+
+	wg.Wait()
+
+	// count files and error if the count isn't what we expected
+	fds, err := ioutil.ReadDir(dir)
+	if err != nil || len(fds) != len(ofacFilenames) {
+		return "", fmt.Errorf("OFAC: problem downloading (found=%d, expected=%d): err=%v", len(fds), len(ofacFilenames), err)
+	}
+
+	return dir, nil
+}

--- a/download_test.go
+++ b/download_test.go
@@ -1,0 +1,38 @@
+// Copyright 2018 The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package ofac
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+func TestOFACDownloader(t *testing.T) {
+	dl := ofacDownloader{}
+	dir, err := dl.getFiles()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	// check file count
+	fds, err := ioutil.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(fds) != len(ofacFilenames) {
+		t.Errorf("OAFC: expected %d files but found %d", len(fds), len(ofacFilenames))
+	}
+	for i := range fds {
+		name := fds[i].Name()
+		switch name {
+		case "add.csv", "alt.csv", "sdn.csv", "sdn_comments.csv":
+			continue
+		default:
+			t.Errorf("unknown file %s", name)
+		}
+	}
+}


### PR DESCRIPTION
This adds a downloader for OFAC files from the treasury website. It puts the files (with their same names) in a temp directory on the local filesystem. 

**NOTE**: This would be merged into the Reader branch, but I assume we'd just want this to land on master. I'll retarget the PR once the reader PR is merged. 