### PR TITLE
ci: disable Go modules when installing tools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,11 +20,11 @@ matrix:
         directories:
           - "/Users/travis/Library/Caches/go-build" # GOCACHE
 before_install:
-  - go get -u github.com/client9/misspell/cmd/misspell
-  - go get -u golang.org/x/lint/golint
-  - go get github.com/fzipp/gocyclo
-  - go get -u honnef.co/go/tools/cmd/staticcheck
-  - go get golang.org/x/tools/cmd/cover
+  - GO111MODULE=off go get -u github.com/client9/misspell/cmd/misspell
+  - GO111MODULE=off go get -u golang.org/x/lint/golint
+  - GO111MODULE=off go get github.com/fzipp/gocyclo
+  - GO111MODULE=off go get -u honnef.co/go/tools/cmd/staticcheck
+  - GO111MODULE=off go get golang.org/x/tools/cmd/cover
 before_script:
   - GOFILES=$(find . -type f -name '*.go' | grep -v vendor | grep -v client)
 script:


### PR DESCRIPTION
See https://github.com/moov-io/ofac/pull/49 for more detail and https://stackoverflow.com/questions/53368187/go-modules-installing-go-tools 