### PR TITLE
cmd/server: search: don't include spaces in jaroWrinkler distance 

### DIFF
--- a/cmd/server/search.go
+++ b/cmd/server/search.go
@@ -279,7 +279,11 @@ var (
 
 // precompute will lowercase each substring and remove punctuation
 func precompute(s string) string {
-	return strings.ToLower(punctuationReplacer.Replace(s))
+	return chomp(strings.ToLower(punctuationReplacer.Replace(s)))
+}
+
+func chomp(s string) string {
+	return strings.Replace(s, " ", "", -1)
 }
 
 func extractSearchLimit(r *http.Request) int {
@@ -296,6 +300,11 @@ func extractSearchLimit(r *http.Request) int {
 	return limit
 }
 
+// jaroWrinkler runs the similarly named algorithm over the two input strings.
+// For more details see https://en.wikipedia.org/wiki/Jaro%E2%80%93Winkler_distance
+//
+// Right now s1 is assumes to have been passed through `chomp(..)` already and so this
+// func only calls `chomp` for s2.
 func jaroWrinkler(s1, s2 string) float64 {
-	return smetrics.JaroWinkler(s1, s2, 0.7, 4)
+	return smetrics.JaroWinkler(s1, chomp(s2), 0.7, 4)
 }

--- a/cmd/server/search_handlers_test.go
+++ b/cmd/server/search_handlers_test.go
@@ -29,7 +29,7 @@ func TestSearch__Address(t *testing.T) {
 		t.Errorf("bogus status code: %d", w.Code)
 	}
 
-	if v := w.Body.String(); !strings.Contains(v, `"match":0.88`) {
+	if v := w.Body.String(); !strings.Contains(v, `"match":0.89`) {
 		t.Errorf("%#v", v)
 	}
 
@@ -85,7 +85,7 @@ func TestSearch__AltName(t *testing.T) {
 		t.Errorf("bogus status code: %d", w.Code)
 	}
 
-	if v := w.Body.String(); !strings.Contains(v, `"match":0.759`) {
+	if v := w.Body.String(); !strings.Contains(v, `"match":0.783`) {
 		t.Error(v)
 	}
 


### PR DESCRIPTION
`Jane Doe` matching `jan lahore` at 81% seemed a bit high, let's ignore the spaces. 