### PR TITLE
build: release binaries from each platform

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ matrix:
     cache:
       directories:
       - "/Users/travis/Library/Caches/go-build"
+  - os: windows
+    go: 1.11.x
 before_install:
 - go get -u github.com/client9/misspell/cmd/misspell
 - go get -u golang.org/x/lint/golint
@@ -37,6 +39,7 @@ script:
 - gocyclo -over 20 $GOFILES
 - golint -set_exit_status $GOFILES
 - staticcheck ./cmd/*/*.go ./pkg/*/*.go *.go
+- if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then choco install -y mingw; export PATH=/c/tools/mingw64/bin:"$PATH";fi
 after_success:
 - bash <(curl -s https://codecov.io/bash) -X fix
 - make
@@ -48,10 +51,9 @@ deploy:
   provider: releases
   api_key:
     secure: lPJQJFPgzw0eAZwG6A5yG3hMVrkuAeXhZy0wcWpOHWH/Ten2uDPo0hm4W5aoeTLi0ABEL9YWeheZRtq5BY9sxNBZLoGf4duz9q4Nc+WvrJT7dIEaynbK1ou2ycHPU35VX3FY6wdcCBPxcDVNQiKHgreXpY6IbcBj8iDWYaaz945INoN+8LAkceyeonrm7AeqeS2jEmdbxlOAHxGFh2mgP2XylLAIKrWe/tvOEPvn7Hz/EIjTJE7K5+j+UhNFFUd+VtcN8I/qyPrs9IoleIKrU9lx1RcrXA0EPDt+bXFzc233Uwa5lYBsj3mtI1imriCEy9ByA8CEBwYOxa9KQPendkGlwqGrKn3bjDXKuBKM7nsiJWG4uHUABMQGBVDXGXcOJnDsmcaR69sCrNxFWed8R4YpYC/QLZkNVPnw4E08dQ9gaw83I6mUW01/qeFczgDd/HDjhNRB1o6/y4Jb5kPVTRYiQ8p+suAmhPfmIUOKlSjwBTB95LisrWtEud66tzfkV9XdKvuxh0FYdlIGDhexcUEME7ZkYo5gelDPmX4V5NagBmKd+9Y+xYAsqCE/Z3Vy0DWRyGZYZGxWcQ5+8M0XlYrPqBP6saDALM8XI+apNuLa3KKzozS5s4G2F9vSVyFHOS+uhOnAz6gftrL9t6g2E9KHiN43tf2JhNrsVNqZbEs=
+  file_glob: true
   file:
-    - bin/ofac-linux-amd64
-    - bin/ofac-darwin-amd64
-    - bin/ofac-amd64.exe
+    - bin/ofac-*
   on:
     repo: moov-io/ofac
     tags: true

--- a/makefile
+++ b/makefile
@@ -1,3 +1,4 @@
+PLATFORM=$(shell uname -s | tr '[:upper:]' '[:lower:]')
 VERSION := $(shell grep -Eo '(v[0-9]+[\.][0-9]+[\.][0-9]+(-[a-zA-Z0-9]*)?)' version.go)
 
 .PHONY: build build-server build-examples docker release check
@@ -35,9 +36,11 @@ clean:
 	@rm -f openapi-generator-cli-*.jar
 
 dist: clean client build
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o ./bin/ofac-linux-amd64
-	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -o ./bin/ofac-darwin-amd64
-	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -o ./bin/ofac-amd64.exe
+ifeq ($(OS),Windows_NT)
+	CGO_ENABLED=1 GOOS=windows go build -o bin/ofac-windows-amd64.exe github.com/moov-io/ofac/cmd/server
+else
+	CGO_ENABLED=1 GOOS=$(PLATFORM) go build -o bin/ofac-$(PLATFORM)-amd64 github.com/moov-io/ofac/cmd/server
+endif
 
 docker:
 # Main OFAC server Docker image


### PR DESCRIPTION
Cross-Compiling with sqlite is pretty annoying, so let's just try
building and releasing from each OS since TravisCI supports that.

Issue: https://github.com/moov-io/docs/issues/27