### PR TITLE
cmd/server: cleanup HTTP Prometheus metric labels

### DIFF
--- a/cmd/server/http.go
+++ b/cmd/server/http.go
@@ -7,6 +7,7 @@ package main
 import (
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 
 	moovhttp "github.com/moov-io/base/http"
@@ -27,6 +28,20 @@ var (
 )
 
 func wrapResponseWriter(logger log.Logger, w http.ResponseWriter, r *http.Request) http.ResponseWriter {
-	route := fmt.Sprintf("%s%s", strings.ToLower(r.Method), strings.Replace(r.URL.Path, "/", "-", -1)) // TODO(adam): filter out random ID's later
+	route := fmt.Sprintf("%s-%s", strings.ToLower(r.Method), cleanMetricsPath(r.URL.Path))
 	return moovhttp.Wrap(logger, routeHistogram.With("route", route), w, r)
+}
+
+// cleanMetricsPath takes a URL path and formats it for Prometheus metrics
+// This method replaces /'s with -'s and clean out OFAC ID's (which are numeric)
+func cleanMetricsPath(path string) string {
+	parts := strings.Split(path, "/")
+	var out []string
+	for i := range parts {
+		if n, _ := strconv.Atoi(parts[i]); n > 0 || parts[i] == "" {
+			continue
+		}
+		out = append(out, parts[i])
+	}
+	return strings.Join(out, "-")
 }

--- a/cmd/server/http_test.go
+++ b/cmd/server/http_test.go
@@ -15,4 +15,11 @@ func TestHTTP__cleanMetricsPath(t *testing.T) {
 	if v := cleanMetricsPath("/v1/ofac/ping"); v != "v1-ofac-ping" {
 		t.Errorf("got %q", v)
 	}
+	if v := cleanMetricsPath("/v1/ofac/customers/19636f90bc95779e2488b0f7a45c4b68958a2ddd"); v != "v1-ofac-customers" {
+		t.Errorf("got %q", v)
+	}
+	// A value which looks like moov/base.ID, but is off by one character (last letter)
+	if v := cleanMetricsPath("/v1/ofac/customers/19636f90bc95779e2488b0f7a45c4b68958a2ddz"); v != "v1-ofac-customers-19636f90bc95779e2488b0f7a45c4b68958a2ddz" {
+		t.Errorf("got %q", v)
+	}
 }

--- a/cmd/server/http_test.go
+++ b/cmd/server/http_test.go
@@ -1,0 +1,18 @@
+// Copyright 2019 The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"testing"
+)
+
+func TestHTTP__cleanMetricsPath(t *testing.T) {
+	if v := cleanMetricsPath("/v1/ofac/companies/1234"); v != "v1-ofac-companies" {
+		t.Errorf("got %q", v)
+	}
+	if v := cleanMetricsPath("/v1/ofac/ping"); v != "v1-ofac-ping" {
+		t.Errorf("got %q", v)
+	}
+}


### PR DESCRIPTION
Previously, OFAC was reporting metrics like:

```
{app="ofac",route="get-companies-17042"}
{app="ofac",route="delete-companies-21206-watch-ce5bb48f9a36320c27ad2062c595bb2bcba0c658"}
```

These metrics make aggregations a lot less performant and we really want route="get-companies" as the Prometheus label.