### PR TITLE
api: add missing 'notes' field on UpdateCompanyStatus and UpdateCustomerStatus

### DIFF
--- a/client/docs/UpdateCompanyStatus.md
+++ b/client/docs/UpdateCompanyStatus.md
@@ -5,6 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Status** | **string** | manual override of company/SDN sanction status | 
+**Notes** | **string** | Free form notes about manually changing the Company status | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/client/docs/UpdateCustomerStatus.md
+++ b/client/docs/UpdateCustomerStatus.md
@@ -5,6 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Status** | **string** | manual override of customer/SDN sanction status | 
+**Notes** | **string** | Free form notes about manually changing the Customer status | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/client/model_update_company_status.go
+++ b/client/model_update_company_status.go
@@ -13,4 +13,6 @@ package openapi
 type UpdateCompanyStatus struct {
 	// manual override of company/SDN sanction status
 	Status string `json:"status"`
+	// Free form notes about manually changing the Company status
+	Notes string `json:"notes,omitempty"`
 }

--- a/client/model_update_customer_status.go
+++ b/client/model_update_customer_status.go
@@ -13,4 +13,6 @@ package openapi
 type UpdateCustomerStatus struct {
 	// manual override of customer/SDN sanction status
 	Status string `json:"status"`
+	// Free form notes about manually changing the Customer status
+	Notes string `json:"notes,omitempty"`
 }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -640,6 +640,10 @@ components:
           enum:
             - unsafe
             - exception
+        notes:
+          description: Free form notes about manually changing the Company status
+          type: string
+          example: "False positive"
       required:
         - status
     UpdateCustomerStatus:
@@ -651,6 +655,10 @@ components:
           enum:
             - unsafe
             - exception
+        notes:
+          description: Free form notes about manually changing the Customer status
+          type: string
+          example: "False positive"
       required:
         - status
     Search:


### PR DESCRIPTION
I realized this wasn't in the API docs after Wade mentioned needing this ability in OFAC. 