### PR TITLE
cmd/server: search: handle Country and average weight with Address

### DIFF
--- a/client/api_ofac.go
+++ b/client/api_ofac.go
@@ -1390,6 +1390,7 @@ OFACApiService Search SDN names and metadata
  * @param "Q" (optional.String) -  Search across Name, Alt Names, and Address fields for all SDN entries. Entries may be returned in all response sub-objects.
  * @param "Name" (optional.String) -  Name which could correspond to a human on the SDN list. Only SDN results will be returned.
  * @param "Address" (optional.String) -  Phsical address which could correspond to a human on the SDN list. Only Address results will be returned.
+ * @param "Country" (optional.String) -  Country name as desginated by SDN guidelines. Only Address results will be returned.
  * @param "AltName" (optional.String) -  Alternate name which could correspond to a human on the SDN list. Only Alt name results will be returned.
  * @param "Limit" (optional.Int32) -  Maximum results returned by a search
 @return Search
@@ -1400,6 +1401,7 @@ type SearchOpts struct {
 	Q          optional.String
 	Name       optional.String
 	Address    optional.String
+	Country    optional.String
 	AltName    optional.String
 	Limit      optional.Int32
 }
@@ -1429,6 +1431,9 @@ func (a *OFACApiService) Search(ctx context.Context, localVarOptionals *SearchOp
 	}
 	if localVarOptionals != nil && localVarOptionals.Address.IsSet() {
 		localVarQueryParams.Add("address", parameterToString(localVarOptionals.Address.Value(), ""))
+	}
+	if localVarOptionals != nil && localVarOptionals.Country.IsSet() {
+		localVarQueryParams.Add("country", parameterToString(localVarOptionals.Country.Value(), ""))
 	}
 	if localVarOptionals != nil && localVarOptionals.AltName.IsSet() {
 		localVarQueryParams.Add("altName", parameterToString(localVarOptionals.AltName.Value(), ""))

--- a/client/docs/OFACApi.md
+++ b/client/docs/OFACApi.md
@@ -678,6 +678,7 @@ Name | Type | Description  | Notes
  **q** | **optional.String**| Search across Name, Alt Names, and Address fields for all SDN entries. Entries may be returned in all response sub-objects. | 
  **name** | **optional.String**| Name which could correspond to a human on the SDN list. Only SDN results will be returned. | 
  **address** | **optional.String**| Phsical address which could correspond to a human on the SDN list. Only Address results will be returned. | 
+ **country** | **optional.String**| Country name as desginated by SDN guidelines. Only Address results will be returned. | 
  **altName** | **optional.String**| Alternate name which could correspond to a human on the SDN list. Only Alt name results will be returned. | 
  **limit** | **optional.Int32**| Maximum results returned by a search | 
 

--- a/cmd/server/search_handlers_test.go
+++ b/cmd/server/search_handlers_test.go
@@ -42,6 +42,34 @@ func TestSearch__Address(t *testing.T) {
 	if wrapper.Addresses[0].EntityID != "173" {
 		t.Errorf("%#v", wrapper.Addresses[0])
 	}
+
+	// send an empty body and get an error
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/search?limit=1", nil)
+	router.ServeHTTP(w, req)
+	w.Flush()
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("bogus status code: %d", w.Code)
+	}
+}
+
+func TestSearch__AddressMulti(t *testing.T) {
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/search?address=ibex+house&country=united+kingdom&limit=1", nil)
+
+	router := mux.NewRouter()
+	addSearchRoutes(nil, router, addressSearcher)
+	router.ServeHTTP(w, req)
+	w.Flush()
+
+	if w.Code != http.StatusOK {
+		t.Errorf("bogus status code: %d", w.Code)
+	}
+
+	if v := w.Body.String(); !strings.Contains(v, `"match":0.945`) {
+		t.Errorf("%#v", v)
+	}
 }
 
 func TestSearch__NameAndAltName(t *testing.T) {

--- a/cmd/server/search_handlers_test.go
+++ b/cmd/server/search_handlers_test.go
@@ -54,6 +54,24 @@ func TestSearch__Address(t *testing.T) {
 	}
 }
 
+func TestSearch__AddressCountry(t *testing.T) {
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/search?country=united+kingdom&limit=1", nil)
+
+	router := mux.NewRouter()
+	addSearchRoutes(nil, router, addressSearcher)
+	router.ServeHTTP(w, req)
+	w.Flush()
+
+	if w.Code != http.StatusOK {
+		t.Errorf("bogus status code: %d", w.Code)
+	}
+
+	if v := w.Body.String(); !strings.Contains(v, `"match":1`) {
+		t.Errorf("%#v", v)
+	}
+}
+
 func TestSearch__AddressMulti(t *testing.T) {
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/search?address=ibex+house&country=united+kingdom&limit=1", nil)

--- a/cmd/server/search_test.go
+++ b/cmd/server/search_test.go
@@ -175,6 +175,36 @@ func TestSearch_liveData(t *testing.T) {
 	}
 }
 
+func TestSearch__topAddressesAddress(t *testing.T) {
+	it := topAddressesAddress("needle")(&Address{address: "needleee"})
+
+	eql(t, "topAddressesAddress", it.weight, 0.95)
+	if add, ok := it.value.(*Address); !ok || add.address != "needleee" {
+		t.Errorf("got %#v", add)
+	}
+}
+
+func TestSearch__topAddressesCountry(t *testing.T) {
+	it := topAddressesAddress("needle")(&Address{address: "needleee"})
+
+	eql(t, "topAddressesCountry", it.weight, 0.95)
+	if add, ok := it.value.(*Address); !ok || add.address != "needleee" {
+		t.Errorf("got %#v", add)
+	}
+}
+
+func TestSearch__multiAddressCompare(t *testing.T) {
+	it := multiAddressCompare(
+		topAddressesAddress("needle"),
+		topAddressesCountry("other"),
+	)(&Address{address: "needlee", country: "other"})
+
+	eql(t, "multiAddressCompare", it.weight, 0.9857)
+	if add, ok := it.value.(*Address); !ok || add.address != "needlee" || add.country != "other" {
+		t.Errorf("got %#v", add)
+	}
+}
+
 func TestSearch__extractSearchLimit(t *testing.T) {
 	// Too high, fallback to hard max
 	req := httptest.NewRequest("GET", "/?limit=1000", nil)

--- a/cmd/server/search_test.go
+++ b/cmd/server/search_test.go
@@ -256,6 +256,16 @@ func TestSearch__TopAddresses(t *testing.T) {
 	}
 }
 
+func TestSearch__TopAddressFn(t *testing.T) {
+	addresses := addressSearcher.TopAddressesFn(1, topAddressesCountry("United Kingdom"))
+	if len(addresses) == 0 {
+		t.Fatal("empty Addresses")
+	}
+	if addresses[0].Address.EntityID != "173" {
+		t.Errorf("%#v", addresses[0].Address)
+	}
+}
+
 func TestSearch__FindAlts(t *testing.T) {
 	alts := altSearcher.FindAlts(1, "559")
 	if v := len(alts); v != 1 {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -432,6 +432,12 @@ paths:
             type: string
             example: 123 83rd Ave
           description: Phsical address which could correspond to a human on the SDN list. Only Address results will be returned.
+        - name: country
+          in: query
+          schema:
+            type: string
+            example: USA
+          description: Country name as desginated by SDN guidelines. Only Address results will be returned.
         - name: altName
           in: query
           schema:


### PR DESCRIPTION
When a search request contains `?address=..&country=..` we will compute the average match percent between an Address against both compare functions and rank all results accordingly.

Issue: https://github.com/moov-io/ofac/issues/79 