### PR TITLE
cmd/server: rename manual refresh endpoint to /data/refresh

### DIFF
--- a/cmd/server/download_handler.go
+++ b/cmd/server/download_handler.go
@@ -12,7 +12,9 @@ import (
 	"github.com/go-kit/kit/log"
 )
 
-const manualRefreshPath = "/ofac/refresh"
+const (
+	manualRefreshPath = "/data/refresh"
+)
 
 // manualRefreshHandler will register an endpoint on the admin server OFAC data refresh endpoint
 func manualRefreshHandler(logger log.Logger, searcher *searcher, downloadRepo downloadRepository) http.HandlerFunc {

--- a/cmd/server/download_handler_test.go
+++ b/cmd/server/download_handler_test.go
@@ -22,7 +22,7 @@ func TestDownload__manualRefreshPath(t *testing.T) {
 	repo := createTestDownloadRepository(t)
 
 	w := httptest.NewRecorder()
-	req := httptest.NewRequest("GET", manualRefreshPath, nil)
+	req := httptest.NewRequest("GET", "/data/refresh", nil)
 	logger := log.NewNopLogger()
 	manualRefreshHandler(logger, searcher, repo)(w, req)
 	w.Flush()


### PR DESCRIPTION
Issue: https://github.com/moov-io/ofac/issues/98