### PR TITLE
download: check for initial files on first refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Docs: [docs.moov.io](https://docs.moov.io/ofac/) | [api docs](https://api.moov.i
 | `OFAC_DATA_REFRESH` | Interval for OFAC data redownload and reparse. | 12h |
 | `OFAC_DOWNLOAD_TEMPLATE` | HTTP address for downloading raw OFAC files. | (OFAC website) |
 | `DPL_DOWNLOAD_TEMPLATE` | HTTP address for downloading the DPL | (BIS website) |
+| `INITIAL_DATA_DIRECTORY` | Directory filepath with initial files to use instead of downloading. Periodic downloads will replace the initial files. | Empty |
 | `WEBHOOK_BATCH_SIZE` | How many watches to read from database per batch of async searches. | 100 |
 | `LOG_FORMAT` | Format for logging lines to be written as. | Options: `json`, `plain` - Default: `plain` |
 | `HTTP_BIND_ADDRESS` | Address for OFAC to bind its HTTP server on. This overrides the command-line flag `-http.addr`. | Default: `:8084` |

--- a/cmd/server/download.go
+++ b/cmd/server/download.go
@@ -54,7 +54,7 @@ type downloadStats struct {
 func (s *searcher) periodicDataRefresh(interval time.Duration, downloadRepo downloadRepository, updates chan *downloadStats) {
 	for {
 		time.Sleep(interval)
-		stats, err := s.refreshData()
+		stats, err := s.refreshData("")
 		if err != nil {
 			if s.logger != nil {
 				s.logger.Log("main", fmt.Sprintf("ERROR: refreshing OFAC and/or BIS DPL data: %v", err))
@@ -71,13 +71,15 @@ func (s *searcher) periodicDataRefresh(interval time.Duration, downloadRepo down
 
 // refreshData reaches out to the OFAC and BIS Denied Persons List websites to download the latest
 // files and then runs ofac.Reader to parse and index data for searches.
-func (s *searcher) refreshData() (*downloadStats, error) {
+func (s *searcher) refreshData(initialDir string) (*downloadStats, error) {
 	if s.logger != nil {
 		s.logger.Log("download", "Starting refresh of OFAC and DPL data")
 	}
 
 	// Download files
-	dir, err := (&ofac.Downloader{}).GetFiles()
+	dir, err := (&ofac.Downloader{
+		Logger: s.logger,
+	}).GetFiles(initialDir)
 	if err != nil {
 		return nil, fmt.Errorf("ERROR: downloading OFAC and DPL data: %v", err)
 	}

--- a/cmd/server/download_handler.go
+++ b/cmd/server/download_handler.go
@@ -22,7 +22,7 @@ func manualRefreshHandler(logger log.Logger, searcher *searcher, downloadRepo do
 		if logger != nil {
 			logger.Log("main", "admin: refreshing OFAC data")
 		}
-		if stats, err := searcher.refreshData(); err != nil {
+		if stats, err := searcher.refreshData(""); err != nil {
 			if logger != nil {
 				logger.Log("main", fmt.Sprintf("ERROR: admin: problem refreshing OFAC data: %v", err))
 			}

--- a/cmd/server/download_test.go
+++ b/cmd/server/download_test.go
@@ -32,7 +32,7 @@ func TestSearcher__refreshData(t *testing.T) {
 	}
 
 	s := &searcher{}
-	stats, err := s.refreshData()
+	stats, err := s.refreshData("")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -131,7 +131,7 @@ func main() {
 	searcher := &searcher{
 		logger: logger,
 	}
-	if stats, err := searcher.refreshData(); err != nil {
+	if stats, err := searcher.refreshData(os.Getenv("INITIAL_DATA_DIRECTORY")); err != nil {
 		logger.Log("main", fmt.Sprintf("ERROR: failed to download/parse initial OFAC data: %v", err))
 		os.Exit(1)
 	} else {

--- a/cmd/server/search_test.go
+++ b/cmd/server/search_test.go
@@ -186,7 +186,7 @@ func TestSearch_liveData(t *testing.T) {
 	searcher := &searcher{
 		logger: log.NewNopLogger(),
 	}
-	if stats, err := searcher.refreshData(); err != nil {
+	if stats, err := searcher.refreshData(""); err != nil {
 		t.Fatal(err)
 	} else {
 		searcher.logger.Log("liveData", fmt.Sprintf("stats: %#v", stats))

--- a/download_test.go
+++ b/download_test.go
@@ -129,4 +129,13 @@ func TestDownloader__initialDir(t *testing.T) {
 	if v := string(bs); v != "file=dpl.txt" {
 		t.Error("unexpected contents in dpl.txt")
 	}
+
+	// use an invalid initial directory to get an error
+	out, err = dl.GetFiles(filepath.Join("this", "path", "doesn't", "exist"))
+	if err == nil {
+		t.Error("expected error")
+	}
+	if len(out) != 0 {
+		t.Errorf("got %d files", len(out))
+	}
 }

--- a/download_test.go
+++ b/download_test.go
@@ -7,8 +7,11 @@ package ofac
 import (
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/go-kit/kit/log"
 )
 
 type fd struct {
@@ -52,8 +55,10 @@ func TestDownloader__compareNames(t *testing.T) {
 }
 
 func TestDownloader(t *testing.T) {
-	dl := Downloader{}
-	dir, err := dl.GetFiles()
+	dl := Downloader{
+		Logger: log.NewNopLogger(),
+	}
+	dir, err := dl.GetFiles("")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -77,5 +82,51 @@ func TestDownloader(t *testing.T) {
 		default:
 			t.Errorf("unknown file %s", name)
 		}
+	}
+}
+
+func TestDownloader__initialDir(t *testing.T) {
+	dir, err := ioutil.TempDir("", "iniital-dir")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	mk := func(t *testing.T, name string, body string) {
+		if err := ioutil.WriteFile(filepath.Join(dir, name), []byte(body), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// create each file
+	mk(t, "add.csv", "file=add.csv")
+	mk(t, "alt.csv", "file=alt.csv")
+	mk(t, "sdn.csv", "file=sdn.csv")
+	mk(t, "sdn_comments.csv", "file=sdn_comments.csv")
+	mk(t, "dpl.txt", "file=dpl.txt")
+
+	dl := Downloader{
+		// Logger: log.NewNopLogger(), // nil so GetFiles sets this
+	}
+	out, err := dl.GetFiles(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// read a couple files
+	bs, err := ioutil.ReadFile(filepath.Join(out, "add.csv"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v := string(bs); v != "file=add.csv" {
+		t.Error("unexpected contents in add.csv")
+	}
+	// read another file
+	bs, err = ioutil.ReadFile(filepath.Join(out, "dpl.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v := string(bs); v != "file=dpl.txt" {
+		t.Error("unexpected contents in dpl.txt")
 	}
 }


### PR DESCRIPTION
From reading the environment variable INITIAL_DATA_DIRECTORY OFAC checks for files to use as the initial data source until a periodic refresh is executed.

Issue: https://github.com/moov-io/ofac/issues/112 