### PR TITLE
cmd/server: disable perioidic refresh via OFAC_DATA_REFRESH=off

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Docs: [docs.moov.io](https://docs.moov.io/ofac/) | [api docs](https://api.moov.i
 
 | Environmental Variable | Description | Default |
 |-----|-----|-----|
-| `OFAC_DATA_REFRESH` | Interval for OFAC data redownload and reparse. | 12h |
+| `OFAC_DATA_REFRESH` | Interval for OFAC data redownload and reparse. `off` disables this refreshing. | 12h |
 | `OFAC_DOWNLOAD_TEMPLATE` | HTTP address for downloading raw OFAC files. | (OFAC website) |
 | `DPL_DOWNLOAD_TEMPLATE` | HTTP address for downloading the DPL | (BIS website) |
 | `INITIAL_DATA_DIRECTORY` | Directory filepath with initial files to use instead of downloading. Periodic downloads will replace the initial files. | Empty |

--- a/cmd/server/download.go
+++ b/cmd/server/download.go
@@ -52,6 +52,10 @@ type downloadStats struct {
 // periodicDataRefresh will forever block for interval's duration and then download and reparse the OFAC data.
 // Download stats are recorded as part of a successful re-download and parse.
 func (s *searcher) periodicDataRefresh(interval time.Duration, downloadRepo downloadRepository, updates chan *downloadStats) {
+	if interval == 0*time.Second {
+		s.logger.Log("download", fmt.Sprintf("not scheduling periodic refreshing duration=%v", interval))
+		return
+	}
 	for {
 		time.Sleep(interval)
 		stats, err := s.refreshData("")

--- a/cmd/server/download_test.go
+++ b/cmd/server/download_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/moov-io/ofac/internal/database"
 
@@ -17,13 +18,21 @@ import (
 )
 
 func TestSearcher__refreshInterval(t *testing.T) {
-	if v := getOFACRefreshInterval(nil, ""); v.String() != "12h0m0s" {
+	if v := getOFACRefreshInterval(log.NewNopLogger(), ""); v.String() != "12h0m0s" {
 		t.Errorf("Got %v", v)
 	}
-	// override
-	if v := getOFACRefreshInterval(nil, "60s"); v.String() != "1m0s" {
+	if v := getOFACRefreshInterval(log.NewNopLogger(), "60s"); v.String() != "1m0s" {
 		t.Errorf("Got %v", v)
 	}
+	if v := getOFACRefreshInterval(log.NewNopLogger(), "off"); v != 0*time.Second {
+		t.Errorf("got %v", v)
+	}
+
+	// cover another branch
+	s := &searcher{
+		logger: log.NewNopLogger(),
+	}
+	s.periodicDataRefresh(0*time.Second, nil, nil)
 }
 
 func TestSearcher__refreshData(t *testing.T) {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -198,16 +198,19 @@ func addPingRoute(r *mux.Router) {
 	})
 }
 
+// getOFACRefreshInterval returns a time.Duration for how often OFAC should refresh data
+//
 // env is the value from an environmental variable
 func getOFACRefreshInterval(logger log.Logger, env string) time.Duration {
 	if env != "" {
-		dur, _ := time.ParseDuration(env)
-		if dur > 0 {
-			if logger != nil {
-				logger.Log("main", fmt.Sprintf("Setting OFAC data refresh interval to %v", dur))
-			}
+		if strings.EqualFold(env, "off") {
+			return 0 * time.Second
+		}
+		if dur, _ := time.ParseDuration(env); dur > 0 {
+			logger.Log("main", fmt.Sprintf("Setting OFAC data refresh interval to %v", dur))
 			return dur
 		}
 	}
+	logger.Log("main", fmt.Sprintf("Setting OFAC data refresh interval to %v (default)", ofacDataRefreshInterval))
 	return ofacDataRefreshInterval
 }

--- a/download.go
+++ b/download.go
@@ -5,6 +5,7 @@
 package ofac
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -59,6 +60,9 @@ type Downloader struct {
 //
 // Callers are expected to cleanup the temp directory.
 func (dl *Downloader) GetFiles(initialDir string) (string, error) {
+	if dl == nil {
+		return "", errors.New("nil Downloader")
+	}
 	if dl.HTTP == nil {
 		dl.HTTP = http.DefaultClient
 	}

--- a/download_test.go
+++ b/download_test.go
@@ -83,6 +83,12 @@ func TestDownloader(t *testing.T) {
 			t.Errorf("unknown file %s", name)
 		}
 	}
+
+	// nil Downloader
+	var dl2 *Downloader
+	if _, err := dl2.GetFiles(""); err == nil {
+		t.Error("expected error")
+	}
 }
 
 func TestDownloader__initialDir(t *testing.T) {


### PR DESCRIPTION
Disabling this allows users to have more control of when data is updated. 

Issue: https://github.com/moov-io/ofac/issues/112