### PR TITLE
cmd/server: accept additional query params to filter SDN search results

### DIFF
--- a/client/api/openapi.yaml
+++ b/client/api/openapi.yaml
@@ -821,6 +821,26 @@ paths:
           example: 25
           type: integer
         style: form
+      - description: Optional filter to only return SDNs whose type case-insensitively
+          matches
+        explode: true
+        in: query
+        name: sdnType
+        required: false
+        schema:
+          example: individual
+          type: string
+        style: form
+      - description: Optional filter to only return SDNs whose program case-insensitively
+          matches
+        explode: true
+        in: query
+        name: program
+        required: false
+        schema:
+          example: SDGT
+          type: string
+        style: form
       responses:
         200:
           content:

--- a/client/api_ofac.go
+++ b/client/api_ofac.go
@@ -1473,6 +1473,8 @@ OFACApiService Search SDN names and metadata
  * @param "Country" (optional.String) -  Country name as desginated by SDN guidelines. Only Address results will be returned.
  * @param "AltName" (optional.String) -  Alternate name which could correspond to a human on the SDN list. Only Alt name results will be returned.
  * @param "Limit" (optional.Int32) -  Maximum results returned by a search
+ * @param "SdnType" (optional.String) -  Optional filter to only return SDNs whose type case-insensitively matches
+ * @param "Program" (optional.String) -  Optional filter to only return SDNs whose program case-insensitively matches
 @return Search
 */
 
@@ -1489,6 +1491,8 @@ type SearchOpts struct {
 	Country    optional.String
 	AltName    optional.String
 	Limit      optional.Int32
+	SdnType    optional.String
+	Program    optional.String
 }
 
 func (a *OFACApiService) Search(ctx context.Context, localVarOptionals *SearchOpts) (Search, *http.Response, error) {
@@ -1537,6 +1541,12 @@ func (a *OFACApiService) Search(ctx context.Context, localVarOptionals *SearchOp
 	}
 	if localVarOptionals != nil && localVarOptionals.Limit.IsSet() {
 		localVarQueryParams.Add("limit", parameterToString(localVarOptionals.Limit.Value(), ""))
+	}
+	if localVarOptionals != nil && localVarOptionals.SdnType.IsSet() {
+		localVarQueryParams.Add("sdnType", parameterToString(localVarOptionals.SdnType.Value(), ""))
+	}
+	if localVarOptionals != nil && localVarOptionals.Program.IsSet() {
+		localVarQueryParams.Add("program", parameterToString(localVarOptionals.Program.Value(), ""))
 	}
 	// to determine the Content-Type header
 	localVarHttpContentTypes := []string{}

--- a/client/docs/OFACApi.md
+++ b/client/docs/OFACApi.md
@@ -701,6 +701,8 @@ Name | Type | Description  | Notes
  **country** | **optional.String**| Country name as desginated by SDN guidelines. Only Address results will be returned. | 
  **altName** | **optional.String**| Alternate name which could correspond to a human on the SDN list. Only Alt name results will be returned. | 
  **limit** | **optional.Int32**| Maximum results returned by a search | 
+ **sdnType** | **optional.String**| Optional filter to only return SDNs whose type case-insensitively matches | 
+ **program** | **optional.String**| Optional filter to only return SDNs whose program case-insensitively matches | 
 
 ### Return type
 

--- a/cmd/server/filter.go
+++ b/cmd/server/filter.go
@@ -1,0 +1,61 @@
+// Copyright 2019 The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"net/url"
+	"strings"
+)
+
+type filterRequest struct {
+	sdnType string
+	program string
+}
+
+func (req filterRequest) empty() bool {
+	return req.sdnType == "" && req.program == ""
+}
+
+func buildFilterRequest(u *url.URL) filterRequest {
+	return filterRequest{
+		sdnType: u.Query().Get("sdnType"),
+		program: u.Query().Get("program"),
+	}
+}
+
+func filterSDNs(sdns []SDN, req filterRequest) []SDN {
+	if req.empty() {
+		// short-circuit and return if we have no filters
+		return sdns
+	}
+
+	var out []SDN
+	for i := range sdns {
+		// by default exclude the result (as at least one filter is non-empty)
+		keep := false
+
+		// Look at all our filters
+		// If the filter is non-empty AND matches the SDN's field then keep it
+		if req.sdnType != "" {
+			if strings.EqualFold(sdns[i].SDNType, req.sdnType) {
+				keep = true
+			} else {
+				continue // skip this SDN as the filter didn't match
+			}
+		}
+		if req.program != "" {
+			if strings.EqualFold(sdns[i].Program, req.program) {
+				keep = true
+			} else {
+				continue
+			}
+		}
+
+		if keep {
+			out = append(out, sdns[i])
+		}
+	}
+	return out
+}

--- a/cmd/server/filter_test.go
+++ b/cmd/server/filter_test.go
@@ -1,0 +1,130 @@
+// Copyright 2019 The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/moov-io/ofac"
+)
+
+func TestFilter__buildFilterRequest(t *testing.T) {
+	u, _ := url.Parse("/search?q=jane+doe&sdnType=individual&program=SDGT")
+	req := buildFilterRequest(u)
+	if req.empty() {
+		t.Error("filterRequest is not empty")
+	}
+	if req.sdnType != "individual" {
+		t.Errorf("req.sdnType=%s", req.sdnType)
+	}
+	if req.program != "SDGT" {
+		t.Errorf("req.program=%s", req.program)
+	}
+
+	// just the sdnType filter
+	u, _ = url.Parse("/search?q=jane+doe&sdnType=individual")
+	req = buildFilterRequest(u)
+	if req.empty() {
+		t.Error("filterRequest is not empty")
+	}
+	if req.sdnType != "individual" {
+		t.Errorf("req.sdnType=%s", req.sdnType)
+	}
+	if req.program != "" {
+		t.Errorf("req.program=%s", req.program)
+	}
+
+	// empty request
+	u, _ = url.Parse("/search?q=jane+doe")
+	req = buildFilterRequest(u)
+	if !req.empty() {
+		t.Error("filterRequest is empty")
+	}
+	if req.sdnType != "" || req.program != "" {
+		t.Errorf("req.sdnType=%s req.program=%s", req.sdnType, req.program)
+	}
+}
+
+var (
+	filterableSDNs = []SDN{
+		{
+			SDN: &ofac.SDN{
+				EntityID: "12",
+				SDNName:  "Jane Doe",
+				SDNType:  "individual",
+				Program:  "other",
+			},
+		},
+		{
+			SDN: &ofac.SDN{
+				EntityID: "13",
+				SDNName:  "EP-1111",
+				SDNType:  "aircraft",
+				Program:  "SDGT",
+			},
+		},
+	}
+)
+
+func TestFilter__sdnType(t *testing.T) {
+	sdns := filterSDNs(filterableSDNs, filterRequest{sdnType: "individual"})
+	if len(sdns) != 1 {
+		t.Errorf("got: %#v", sdns)
+	}
+	if sdns[0].EntityID != "12" {
+		t.Errorf("sdns[0].EntityID=%s", sdns[0].EntityID)
+	}
+
+	sdns = filterSDNs(filterableSDNs, filterRequest{})
+	if len(sdns) != 2 {
+		t.Errorf("got %#v", sdns)
+	}
+
+	sdns = filterSDNs(filterableSDNs, filterRequest{sdnType: "other"})
+	if len(sdns) != 0 {
+		t.Errorf("got %#v", sdns)
+	}
+}
+
+func TestFilter__program(t *testing.T) {
+	sdns := filterSDNs(filterableSDNs, filterRequest{program: "SDGT"})
+	if len(sdns) != 1 {
+		t.Errorf("got: %#v", sdns)
+	}
+	if sdns[0].EntityID != "13" {
+		t.Errorf("sdns[0].EntityID=%s", sdns[0].EntityID)
+	}
+
+	sdns = filterSDNs(filterableSDNs, filterRequest{})
+	if len(sdns) != 2 {
+		t.Errorf("got %#v", sdns)
+	}
+
+	sdns = filterSDNs(filterableSDNs, filterRequest{program: "unknown"})
+	if len(sdns) != 0 {
+		t.Errorf("got %#v", sdns)
+	}
+}
+
+func TestFilter__multiple(t *testing.T) {
+	sdns := filterSDNs(filterableSDNs, filterRequest{sdnType: "aircraft", program: "SDGT"})
+	if len(sdns) != 1 {
+		t.Errorf("got: %#v", sdns)
+	}
+	if sdns[0].EntityID != "13" {
+		t.Errorf("sdns[0].EntityID=%s", sdns[0].EntityID)
+	}
+
+	sdns = filterSDNs(filterableSDNs, filterRequest{})
+	if len(sdns) != 2 {
+		t.Errorf("got %#v", sdns)
+	}
+
+	sdns = filterSDNs(filterableSDNs, filterRequest{sdnType: "other", program: "unknown"})
+	if len(sdns) != 0 {
+		t.Errorf("got %#v", sdns)
+	}
+}

--- a/cmd/server/search_handlers.go
+++ b/cmd/server/search_handlers.go
@@ -152,7 +152,7 @@ func searchViaQ(logger log.Logger, searcher *searcher, name string) http.Handler
 
 		limit := extractSearchLimit(r)
 		response := &searchResponse{
-			SDNs:          searcher.TopSDNs(limit, name),
+			SDNs:          filterSDNs(searcher.TopSDNs(limit, name), buildFilterRequest(r.URL)),
 			AltNames:      searcher.TopAltNames(limit, name),
 			Addresses:     searcher.TopAddresses(limit, name),
 			DeniedPersons: searcher.TopDPs(limit, name),
@@ -174,7 +174,9 @@ func searchByName(logger log.Logger, searcher *searcher, nameSlug string) http.H
 			return
 		}
 
+		// Grab the SDN's and then filter any out based on query params
 		sdns := searcher.TopSDNs(extractSearchLimit(r), nameSlug)
+		sdns = filterSDNs(sdns, buildFilterRequest(r.URL))
 
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		w.WriteHeader(http.StatusOK)

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -634,6 +634,18 @@ paths:
             type: integer
             example: 25
           description: Maximum results returned by a search
+        - name: sdnType
+          in: query
+          schema:
+            type: string
+            example: individual
+          description: Optional filter to only return SDNs whose type case-insensitively matches
+        - name: program
+          in: query
+          schema:
+            type: string
+            example: SDGT
+          description: Optional filter to only return SDNs whose program case-insensitively matches
       responses:
         '200':
           description: SDNs returned from a search


### PR DESCRIPTION


Various compliance assessments of OFAC data require filtering around
the government program this data is associated with or to be more
specific about the SDN's type (aircraft vs individual).

Fixes: #133