### PR TITLE
cmd/server: add endpoint for applications to grab distinct sets of column values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ ADDITIONS
 - cmd/server: add the web interface developed by Linden Lab
 - cmd/server: accept additional query params to filter SDN search results
   - `?sdnType=individual` and `?program=example`
+- cmd/server: add endpoint for applications to grab distinct sets of column values
+  - `GET /ui/values/sdnType` returns `["aircraft","individual","vessel"]`
 
 IMPROVEMENTS
 

--- a/cmd/server/filter.go
+++ b/cmd/server/filter.go
@@ -38,6 +38,8 @@ func filterSDNs(sdns []SDN, req filterRequest) []SDN {
 
 		// Look at all our filters
 		// If the filter is non-empty AND matches the SDN's field then keep it
+		//
+		// TODO(adam): If we add more filters don't forget to also add them in values.go
 		if req.sdnType != "" {
 			if strings.EqualFold(sdns[i].SDNType, req.sdnType) {
 				keep = true

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -166,6 +166,7 @@ func main() {
 	addSDNRoutes(logger, router, searcher)
 	addSearchRoutes(logger, router, searcher)
 	addDownloadRoutes(logger, router, downloadRepo)
+	addValuesRoutes(logger, router, searcher)
 
 	// Setup our web UI to be served as well
 	setupWebui(logger, router)

--- a/cmd/server/values.go
+++ b/cmd/server/values.go
@@ -17,7 +17,7 @@ import (
 	"github.com/gorilla/mux"
 )
 
-// accumulator is a case-insensitve collector for string values.
+// accumulator is a case-insensitive collector for string values.
 //
 // getValues() will return an orderd distinct array of accumulated strings
 // where each string is the first seen instance.
@@ -61,8 +61,7 @@ func addValuesRoutes(logger log.Logger, r *mux.Router, searcher *searcher) {
 }
 
 func getKey(r *http.Request) string {
-	v, _ := mux.Vars(r)["key"]
-	return strings.ToLower(v)
+	return strings.ToLower(mux.Vars(r)["key"])
 }
 
 func getValues(logger log.Logger, searcher *searcher) http.HandlerFunc {

--- a/cmd/server/values.go
+++ b/cmd/server/values.go
@@ -1,0 +1,77 @@
+// Copyright 2019 The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+
+	moovhttp "github.com/moov-io/base/http"
+
+	"github.com/go-kit/kit/log"
+	"github.com/gorilla/mux"
+)
+
+// accumulator is a case-insensitve collector for string values.
+//
+// values() will return an orderd distinct array of accumulated strings
+// where each string is the first seen instance.
+type accumulator map[string]string
+
+func (acc accumulator) add(value string) {
+	norm := strings.ToLower(strings.TrimSpace(value))
+	if norm == "" {
+		return
+	}
+	if _, exists := acc[norm]; !exists {
+		acc[norm] = value
+	}
+}
+
+func (acc accumulator) values() []string {
+	var out []string
+	for _, v := range acc {
+		out = append(out, v)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func addValuesRoutes(logger log.Logger, r *mux.Router, searcher *searcher) {
+	r.Methods("GET").Path("/ui/values/{key}").HandlerFunc(getValues(logger, searcher))
+}
+
+func getKey(r *http.Request) string {
+	v, _ := mux.Vars(r)["key"]
+	return strings.ToLower(v)
+}
+
+func getValues(logger log.Logger, searcher *searcher) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w = wrapResponseWriter(logger, w, r)
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+
+		acc := make(accumulator)
+		for i := range searcher.SDNs {
+			// If we add support for other filters (CallSign, Tonnage)
+			// then we should add those keys here.
+			switch k := getKey(r); k {
+			case "sdntype":
+				acc.add(searcher.SDNs[i].SDNType)
+			case "program":
+				acc.add(searcher.SDNs[i].Program)
+			default:
+				moovhttp.Problem(w, fmt.Errorf("unknown key: %s", k))
+				return
+			}
+		}
+
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(acc.values())
+	}
+}

--- a/cmd/server/values_test.go
+++ b/cmd/server/values_test.go
@@ -15,18 +15,24 @@ import (
 )
 
 func TestValues__accumulator(t *testing.T) {
-	acc := make(accumulator)
+	acc := newAccumulator(2)
 	acc.add("v2") // out of alphanumeric order
+	acc.add("")   // empty value, ignored
 	acc.add("v1")
 	acc.add("v1") // duplicate
-	acc.add("")   // empty value
 
-	xs := acc.values()
+	xs := acc.getValues()
 	if len(xs) != 2 {
 		t.Errorf("got values: %v", xs)
 	}
 	if xs[0] != "v1" || xs[1] != "v2" {
 		t.Errorf("values: %v", xs)
+	}
+
+	// add another past the limit and expect it to be excluded
+	acc.add("v3")
+	if len(xs) != 2 {
+		t.Errorf("got values: %v", xs)
 	}
 }
 
@@ -52,6 +58,28 @@ func TestValues__getValues(t *testing.T) {
 	}
 	if values[0] != "individual" {
 		t.Errorf("values[0]=%s", values[0])
+	}
+}
+
+func TestValues__getValuesLimit(t *testing.T) {
+	router := mux.NewRouter()
+	addValuesRoutes(log.NewNopLogger(), router, sdnSearcher)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/ui/values/program?limit=1", nil)
+	router.ServeHTTP(w, req)
+	w.Flush()
+
+	if w.Code != http.StatusOK {
+		t.Errorf("bogus HTTP status: %d", w.Code)
+	}
+
+	var values []string
+	if err := json.NewDecoder(w.Body).Decode(&values); err != nil {
+		t.Error(err)
+	}
+	if len(values) != 1 {
+		t.Errorf("values: %v", values)
 	}
 }
 

--- a/cmd/server/values_test.go
+++ b/cmd/server/values_test.go
@@ -1,0 +1,70 @@
+// Copyright 2019 The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-kit/kit/log"
+	"github.com/gorilla/mux"
+)
+
+func TestValues__accumulator(t *testing.T) {
+	acc := make(accumulator)
+	acc.add("v2") // out of alphanumeric order
+	acc.add("v1")
+	acc.add("v1") // duplicate
+	acc.add("")   // empty value
+
+	xs := acc.values()
+	if len(xs) != 2 {
+		t.Errorf("got values: %v", xs)
+	}
+	if xs[0] != "v1" || xs[1] != "v2" {
+		t.Errorf("values: %v", xs)
+	}
+}
+
+func TestValues__getValues(t *testing.T) {
+	router := mux.NewRouter()
+	addValuesRoutes(log.NewNopLogger(), router, sdnSearcher)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/ui/values/sdnType", nil)
+	router.ServeHTTP(w, req)
+	w.Flush()
+
+	if w.Code != http.StatusOK {
+		t.Errorf("bogus HTTP status: %d", w.Code)
+	}
+
+	var values []string
+	if err := json.NewDecoder(w.Body).Decode(&values); err != nil {
+		t.Error(err)
+	}
+	if len(values) != 1 {
+		t.Errorf("values: %v", values)
+	}
+	if values[0] != "individual" {
+		t.Errorf("values[0]=%s", values[0])
+	}
+}
+
+func TestValues__getValuesErr(t *testing.T) {
+	router := mux.NewRouter()
+	addValuesRoutes(log.NewNopLogger(), router, sdnSearcher)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/ui/values/other", nil)
+	router.ServeHTTP(w, req)
+	w.Flush()
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("bogus HTTP status: %d: %s", w.Code, w.Body.String())
+	}
+}


### PR DESCRIPTION
UI applications (web pages, dropdowns, etc) often are more useful to the user if they can show possible values for a column. This change adds an endpoint for doing exactly that:

```
GET /ui/values/sdnType
```

This would return:

```
["aircraft","individual","vessel"]
```

Also, `?limit=2` is supported with a default of 10 and max of 100 (just like search results). 

Edit: This endpoint would be used with the [recently added filter](https://github.com/moov-io/ofac/pull/134) query parameters (and to pre-fill the UI). 

Examples: https://gist.github.com/adamdecaf/6d9ec68dbce0308695057953dc38a0a2