### PR TITLE
webui: sync url and search state

### DIFF
--- a/webui/package.json
+++ b/webui/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "express": "4.17.1",
     "express-winston": "3.3.0",
+    "history": "^4.10.1",
     "http-proxy-middleware": "0.20.0",
     "react": "16.10.1",
     "react-dom": "16.10.1",

--- a/webui/package.json
+++ b/webui/package.json
@@ -16,7 +16,8 @@
     "build": "react-scripts build",
     "ofac-server": "docker run -p 8084:8084 -p 9094:9094 -it moov/ofac:latest",
     "server": "node server/index.js",
-    "start": "react-scripts start"
+    "start": "react-scripts start",
+    "test": "react-scripts test"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/webui/src/Form/index.js
+++ b/webui/src/Form/index.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useCallback, useEffect } from "react";
 import * as R from "ramda";
 import styled from "styled-components/macro"; // eslint-disable-line no-unused-vars
 import MButton from "@material-ui/core/Button";
@@ -8,6 +8,7 @@ import Select from "./Select";
 import TextInput from "./TextInput";
 import Slider from "./Slider";
 import { countryOptionData, listOptionData, typeOptionData, programOptionData } from "../data";
+import { parseQueryString } from "utils";
 
 const Button = styled(MButton)`
   margin: 1em;
@@ -44,13 +45,13 @@ const initialValues = {
   country: "",
   zip: "",
   limit: 10,
-  q: "",
+  q: ""
   // disabled ///////////
-  idNumber: "",
-  type: "All",
-  program: ["All"],
-  list: "All",
-  score: 100
+  // idNumber: "",
+  // type: "All",
+  // program: ["All"],
+  // list: "All",
+  // score: 100
 };
 
 export default ({ onSubmit, onReset }) => {
@@ -66,7 +67,6 @@ export default ({ onSubmit, onReset }) => {
 
   const handleSearchClick = () => {
     const activeValues = R.omit(["idNumber", "type", "program", "list", "score"])(values);
-    // TODO: validate input for sanity
     onSubmit(activeValues);
   };
 
@@ -74,6 +74,19 @@ export default ({ onSubmit, onReset }) => {
     setValues(initialValues);
     onReset();
   };
+
+  const submit = useCallback(onSubmit, []);
+  useEffect(() => {
+    const { search } = window.location;
+    if (!search) {
+      return;
+    }
+    setValues(values => {
+      const newValues = R.mergeDeepRight(values, parseQueryString(search));
+      submit(newValues);
+      return newValues;
+    });
+  }, [submit]);
 
   return (
     <Container>

--- a/webui/src/__tests__/utils.tests.js
+++ b/webui/src/__tests__/utils.tests.js
@@ -1,0 +1,25 @@
+import { buildQueryString, parseQueryString } from "utils";
+
+describe("parseQueryString", () => {
+  it.each([
+    [null, null],
+    ["", ""],
+    [undefined, undefined],
+    ["?limit=1", { limit: "1" }],
+    ["?limit=1&name=nicolas%20maduro", { limit: "1", name: "nicolas maduro" }]
+  ])("should parse %s => %s", (input, expected) => {
+    expect(parseQueryString(input)).toEqual(expected);
+  });
+});
+
+describe("buildQueryString", () => {
+  it.each([
+    [null, null],
+    ["", ""],
+    [undefined, undefined],
+    [{ limit: "1" }, "limit=1"],
+    [{ limit: "1", name: "nicolas maduro" }, "limit=1&name=nicolas%20maduro"]
+  ])("should parse %s => %s", (input, expected) => {
+    expect(buildQueryString(input)).toEqual(expected);
+  });
+});

--- a/webui/src/utils.js
+++ b/webui/src/utils.js
@@ -1,5 +1,18 @@
-import * as R from 'ramda';
+import * as R from "ramda";
 
 export const matchToPercent = match => `${(match * 100).toFixed(1)}%`;
 export const isNilOrEmpty = R.anyPass([R.isNil, R.isEmpty]);
 
+export const buildQueryString = R.pipe(
+  R.filter(R.complement(isNilOrEmpty)),
+  R.mapObjIndexed((val, key) => `${key}=${val}`),
+  R.values,
+  R.join("&")
+);
+
+export const parseQueryString = R.pipe(
+  R.tail,
+  R.split("&"),
+  R.map(R.split("=")),
+  R.fromPairs
+);

--- a/webui/src/utils.js
+++ b/webui/src/utils.js
@@ -3,16 +3,23 @@ import * as R from "ramda";
 export const matchToPercent = match => `${(match * 100).toFixed(1)}%`;
 export const isNilOrEmpty = R.anyPass([R.isNil, R.isEmpty]);
 
-export const buildQueryString = R.pipe(
-  R.filter(R.complement(isNilOrEmpty)),
-  R.mapObjIndexed((val, key) => `${key}=${val}`),
-  R.values,
-  R.join("&")
-);
+export const buildQueryString = v => {
+  if (!v) return v;
+  return R.pipe(
+    R.filter(R.complement(isNilOrEmpty)),
+    R.mapObjIndexed((val, key) => `${key}=${encodeURIComponent(val)}`),
+    R.values,
+    R.join("&")
+  )(v);
+};
 
-export const parseQueryString = R.pipe(
-  R.tail,
-  R.split("&"),
-  R.map(R.split("=")),
-  R.fromPairs
-);
+export const parseQueryString = v => {
+  if (!v) return v;
+  return R.pipe(
+    R.tail,
+    R.split("&"),
+    R.map(R.split("=")),
+    R.fromPairs,
+    R.map(decodeURIComponent)
+  )(v);
+};


### PR DESCRIPTION
We want the ability to save/share webui URLs that include search criteria.

When the app loads, it will parse any criteria in the url, populate search fields and immediately execute a search. The URL is updated with current criteria anytime a search or reset is executed.