### PR TITLE
cmd/server: add /search?id=NNN endpoint for matching remark IDs

### DIFF
--- a/client/api/openapi.yaml
+++ b/client/api/openapi.yaml
@@ -812,6 +812,16 @@ paths:
           example: Jane Smith
           type: string
         style: form
+      - description: ID value often found in remarks property of an SDN. Takes the
+          form of 'No. NNNNN' as an alphanumeric value.
+        explode: true
+        in: query
+        name: id
+        required: false
+        schema:
+          example: "10517860"
+          type: string
+        style: form
       - description: Maximum results returned by a search
         explode: true
         in: query

--- a/client/api_ofac.go
+++ b/client/api_ofac.go
@@ -1579,6 +1579,7 @@ OFACApiService Search SDN names and metadata
  * @param "Zip" (optional.String) -  Zip code as desginated by SDN guidelines. Only Address results will be returned.
  * @param "Country" (optional.String) -  Country name as desginated by SDN guidelines. Only Address results will be returned.
  * @param "AltName" (optional.String) -  Alternate name which could correspond to a human on the SDN list. Only Alt name results will be returned.
+ * @param "Id" (optional.String) -  ID value often found in remarks property of an SDN. Takes the form of 'No. NNNNN' as an alphanumeric value.
  * @param "Limit" (optional.Int32) -  Maximum results returned by a search
  * @param "SdnType" (optional.String) -  Optional filter to only return SDNs whose type case-insensitively matches
  * @param "Program" (optional.String) -  Optional filter to only return SDNs whose program case-insensitively matches
@@ -1597,6 +1598,7 @@ type SearchOpts struct {
 	Zip        optional.String
 	Country    optional.String
 	AltName    optional.String
+	Id         optional.String
 	Limit      optional.Int32
 	SdnType    optional.String
 	Program    optional.String
@@ -1645,6 +1647,9 @@ func (a *OFACApiService) Search(ctx context.Context, localVarOptionals *SearchOp
 	}
 	if localVarOptionals != nil && localVarOptionals.AltName.IsSet() {
 		localVarQueryParams.Add("altName", parameterToString(localVarOptionals.AltName.Value(), ""))
+	}
+	if localVarOptionals != nil && localVarOptionals.Id.IsSet() {
+		localVarQueryParams.Add("id", parameterToString(localVarOptionals.Id.Value(), ""))
 	}
 	if localVarOptionals != nil && localVarOptionals.Limit.IsSet() {
 		localVarQueryParams.Add("limit", parameterToString(localVarOptionals.Limit.Value(), ""))

--- a/client/docs/OFACApi.md
+++ b/client/docs/OFACApi.md
@@ -743,6 +743,7 @@ Name | Type | Description  | Notes
  **zip** | **optional.String**| Zip code as desginated by SDN guidelines. Only Address results will be returned. | 
  **country** | **optional.String**| Country name as desginated by SDN guidelines. Only Address results will be returned. | 
  **altName** | **optional.String**| Alternate name which could correspond to a human on the SDN list. Only Alt name results will be returned. | 
+ **id** | **optional.String**| ID value often found in remarks property of an SDN. Takes the form of &#39;No. NNNNN&#39; as an alphanumeric value. | 
  **limit** | **optional.Int32**| Maximum results returned by a search | 
  **sdnType** | **optional.String**| Optional filter to only return SDNs whose type case-insensitively matches | 
  **program** | **optional.String**| Optional filter to only return SDNs whose program case-insensitively matches | 

--- a/cmd/server/search_handlers_test.go
+++ b/cmd/server/search_handlers_test.go
@@ -244,3 +244,31 @@ func TestSearch__AltName(t *testing.T) {
 		t.Errorf("%#v", wrapper.Alts[0])
 	}
 }
+
+func TestSearch__ID(t *testing.T) {
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/search?id=5892464&limit=2", nil)
+
+	router := mux.NewRouter()
+	addSearchRoutes(log.NewNopLogger(), router, idSearcher)
+	router.ServeHTTP(w, req)
+	w.Flush()
+
+	if w.Code != http.StatusOK {
+		t.Errorf("bogus status code: %d", w.Code)
+	}
+
+	if v := w.Body.String(); !strings.Contains(v, `"match":1`) {
+		t.Error(v)
+	}
+
+	var wrapper struct {
+		SDNs []*ofac.SDN `json:"SDNs"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&wrapper); err != nil {
+		t.Fatal(err)
+	}
+	if wrapper.SDNs[0].EntityID != "22790" {
+		t.Errorf("%#v", wrapper.SDNs[0])
+	}
+}

--- a/cmd/server/search_test.go
+++ b/cmd/server/search_test.go
@@ -72,6 +72,18 @@ var (
 			},
 		}),
 	}
+	idSearcher = &searcher{
+		SDNs: precomputeSDNs([]*ofac.SDN{
+			{
+				EntityID: "22790",
+				SDNName:  "MADURO MOROS, Nicolas",
+				SDNType:  "individual",
+				Program:  "VENEZUELA",
+				Title:    "President of the Bolivarian Republic of Venezuela",
+				Remarks:  "DOB 23 Nov 1962; POB Caracas, Venezuela; citizen Venezuela; Gender Male; Cedula No. 5892464 (Venezuela); President of the Bolivarian Republic of Venezuela.",
+			},
+		}),
+	}
 	dplSearcher = &searcher{
 		DPs: precomputeDPs([]*ofac.DPL{
 			{
@@ -386,5 +398,36 @@ func TestSearch__TopDPs(t *testing.T) {
 	// DPL doesn't have any entity IDs. Comparing expected address components instead
 	if dps[0].DeniedPerson.StreetAddress != "P.O. BOX 28360" || dps[0].DeniedPerson.City != "DUBAI" {
 		t.Errorf("%#v", dps[0].DeniedPerson)
+	}
+}
+
+func TestSearch__extractIDFromRemark(t *testing.T) {
+	cases := []struct {
+		input, expected string
+	}{
+		{"Cedula No. 10517860 (Venezuela);", "10517860"},
+		{"National ID No. 22095919778 (Norway).", "22095919778"},
+		{"Driver's License No. 180839 (Mexico);", "180839"},
+		{"Immigration No. A38839964 (United States).", "A38839964"},
+		{"C.R. No. 79190 (United Arab Emirates).", "79190"},
+		{"Electoral Registry No. RZZVAL62051010M200 (Mexico).", "RZZVAL62051010M200"},
+		{"Trade License No. GE0426505 (Italy).", "GE0426505"},
+		{"Public Security and Immigration No. 98.805", "98.805"},
+		{"Folio Mercantil No. 578349 (Panama).", "578349"},
+		{"Trade License No. C 37422 (Malta).", "C 37422"},
+		{"Moroccan Personal ID No. E 427689 (Morocco) issued 20 Mar 2001.", "E 427689"},
+		{"National ID No. 5-5715-00025-50-6 (Thailand);", "5-5715-00025-50-6"},
+		{"Trade License No. HRB94311.", "HRB94311"},
+		{"Registered Charity No. 1040094.", "1040094"},
+		{"Bosnian Personal ID No. 1005967953038;", "1005967953038"},
+		{"Telephone No. 009613679153;", "009613679153"},
+		{"Tax ID No. AABA 670850 Y.", "AABA 670850"},
+		{"Phone No. 263-4-486946; Fax No. 263-4-487261.", "263-4-486946"},
+	}
+	for i := range cases {
+		result := extractIDFromRemark(cases[i].input)
+		if cases[i].expected != result {
+			t.Errorf("input=%s expected=%s result=%s", cases[i].input, cases[i].expected, result)
+		}
 	}
 }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -628,6 +628,12 @@ paths:
             type: string
             example: Jane Smith
           description: Alternate name which could correspond to a human on the SDN list. Only Alt name results will be returned.
+        - name: id
+          in: query
+          schema:
+            type: string
+            example: '10517860'
+          description: ID value often found in remarks property of an SDN. Takes the form of 'No. NNNNN' as an alphanumeric value.
         - name: limit
           in: query
           schema:


### PR DESCRIPTION


Often SDN remarks will contain government ID values which are unique
to that entity. This can be a really strong signal so we need to allow
clients to query based on those values.

Issue: #141