### PR TITLE
cmd/server: adjust jaro weighting to maximize total weight in strong single word matches

### DIFF
--- a/cmd/server/issue115_test.go
+++ b/cmd/server/issue115_test.go
@@ -14,10 +14,10 @@ import (
 
 func TestIssue115__TopSDNs(t *testing.T) {
 	score := jaroWrinkler("georgehabbash", "georgebush")
-	eql(t, "george bush jaroWrinkler", score, 0.689)
+	eql(t, "george bush jaroWrinkler", score, 0.896)
 
 	score = jaroWrinkler("g", "geoergebush")
-	eql(t, "g vs geoerge bush", score, 0.063)
+	eql(t, "g vs geoergebush", score, 0.697)
 
 	s := &searcher{logger: log.NewNopLogger()}
 
@@ -27,12 +27,12 @@ func TestIssue115__TopSDNs(t *testing.T) {
 	// was 89.6% match
 	s.SDNs = precomputeSDNs([]*ofac.SDN{{EntityID: "2680", SDNName: "HABBASH, George", SDNType: "INDIVIDUAL"}})
 	out := s.TopSDNs(1, "george bush")
-	eql(t, "issue115: top SDN 2680", out[0].match, 0.689)
+	eql(t, "issue115: top SDN 2680", out[0].match, 0.896)
 
 	// was 88.3% match
 	s.SDNs = precomputeSDNs([]*ofac.SDN{{EntityID: "9432", SDNName: "CHIWESHE, George", SDNType: "INDIVIDUAL"}})
 	out = s.TopSDNs(1, "george bush")
-	eql(t, "issue115: top SDN 18996", out[0].match, 0.607)
+	eql(t, "issue115: top SDN 18996", out[0].match, 0.849)
 
 	// another example
 	s.SDNs = precomputeSDNs([]*ofac.SDN{{EntityID: "0", SDNName: "Bush, George W", SDNType: "INDIVIDUAL"}})
@@ -41,7 +41,7 @@ func TestIssue115__TopSDNs(t *testing.T) {
 	}
 
 	out = s.TopSDNs(1, "george bush")
-	eql(t, "issue115: top SDN 0", out[0].match, 0.856)
+	eql(t, "issue115: top SDN 0", out[0].match, 0.942)
 
 	out = s.TopSDNs(1, "george w bush")
 	eql(t, "issue115: top SDN 0", out[0].match, 1.0)

--- a/cmd/server/search.go
+++ b/cmd/server/search.go
@@ -309,7 +309,7 @@ func precomputeSDNs(sdns []*ofac.SDN) []*SDN {
 }
 
 var (
-	surnamePrecedes = regexp.MustCompile(`(,?[\s?a-zA-Z]{1,})$`)
+	surnamePrecedes = regexp.MustCompile(`(,?[\s?a-zA-Z\.]{1,})$`)
 )
 
 // reorderSDNName will take a given SDN name and if it matches a specific pattern where

--- a/cmd/server/search.go
+++ b/cmd/server/search.go
@@ -8,14 +8,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"math"
 	"net/http"
 	"regexp"
 	"strconv"
 	"strings"
 	"sync"
 	"unicode"
-	"unicode/utf8"
 
 	"github.com/moov-io/ofac"
 
@@ -473,7 +471,32 @@ func extractSearchLimit(r *http.Request) int {
 // Right now s1 is assumes to have been passed through `chomp(..)` already and so this
 // func only calls `chomp` for s2.
 func jaroWrinkler(s1, s2 string) float64 {
-	n1, n2 := float64(utf8.RuneCountInString(s1)), float64(utf8.RuneCountInString(s2))
-	ratio := math.Min(n1, n2) / math.Max(n1, n2)
-	return ratio * smetrics.JaroWinkler(s1, chomp(s2), 0.7, 4)
+	maxMatch := func(word string, parts []string) float64 {
+		if len(parts) == 0 {
+			return 0.0
+		}
+		max := smetrics.JaroWinkler(word, parts[0], 0.7, 4)
+		for i := 1; i < len(parts); i++ {
+			if score := smetrics.JaroWinkler(word, parts[i], 0.7, 4); score > max {
+				max = score
+			}
+		}
+		return max
+	}
+
+	var max float64
+	s1Parts, s2Parts := strings.Fields(s1), strings.Fields(chomp(s2))
+	for i := range s1Parts {
+		score := maxMatch(s1Parts[i], s2Parts)
+		if score > 0.99 {
+			// one word matched exactly to our query, so return 100% like OFAC's search service
+			return 1.0
+		}
+		if score > max {
+			max = score
+		} else {
+			max = (max + score) * 0.75
+		}
+	}
+	return max
 }

--- a/cmd/server/search_handlers_test.go
+++ b/cmd/server/search_handlers_test.go
@@ -30,7 +30,7 @@ func TestSearch__Address(t *testing.T) {
 		t.Errorf("bogus status code: %d", w.Code)
 	}
 
-	if v := w.Body.String(); !strings.Contains(v, `"match":0.7845`) {
+	if v := w.Body.String(); !strings.Contains(v, `"match":0.9229`) {
 		t.Errorf("%#v", v)
 	}
 
@@ -86,7 +86,7 @@ func TestSearch__AddressMulti(t *testing.T) {
 		t.Errorf("bogus status code: %d", w.Code)
 	}
 
-	if v := w.Body.String(); !strings.Contains(v, `"match":0.70025`) {
+	if v := w.Body.String(); !strings.Contains(v, `"match":0.945`) {
 		t.Errorf("%#v", v)
 	}
 }
@@ -104,7 +104,7 @@ func TestSearch__AddressProvidence(t *testing.T) {
 		t.Errorf("bogus status code: %d", w.Code)
 	}
 
-	if v := w.Body.String(); !strings.Contains(v, `"match":0.80`) {
+	if v := w.Body.String(); !strings.Contains(v, `"match":0.963`) {
 		t.Errorf("%#v", v)
 	}
 }
@@ -122,7 +122,7 @@ func TestSearch__AddressCity(t *testing.T) {
 		t.Errorf("bogus status code: %d", w.Code)
 	}
 
-	if v := w.Body.String(); !strings.Contains(v, `"match":0.80`) {
+	if v := w.Body.String(); !strings.Contains(v, `"match":0.963`) {
 		t.Errorf("%#v", v)
 	}
 }
@@ -140,14 +140,14 @@ func TestSearch__AddressState(t *testing.T) {
 		t.Errorf("bogus status code: %d", w.Code)
 	}
 
-	if v := w.Body.String(); !strings.Contains(v, `"match":0.80`) {
+	if v := w.Body.String(); !strings.Contains(v, `"match":0.963`) {
 		t.Errorf("%#v", v)
 	}
 }
 
 func TestSearch__NameAndAltName(t *testing.T) {
 	w := httptest.NewRecorder()
-	req := httptest.NewRequest("GET", "/search?limit=1&q=Air+I", nil)
+	req := httptest.NewRequest("GET", "/search?limit=1&q=nayif", nil)
 
 	s := &searcher{
 		Alts:      altSearcher.Alts,
@@ -178,10 +178,10 @@ func TestSearch__NameAndAltName(t *testing.T) {
 	if wrapper.SDNs[0].EntityID != "2681" {
 		t.Errorf("%#v", wrapper.SDNs[0])
 	}
-	if wrapper.AltNames[0].EntityID != "559" {
+	if wrapper.AltNames[0].EntityID != "4691" {
 		t.Errorf("%#v", wrapper.AltNames[0].EntityID)
 	}
-	if wrapper.Addresses[0].EntityID != "735" {
+	if wrapper.Addresses[0].EntityID != "173" {
 		t.Errorf("%#v", wrapper.Addresses[0].EntityID)
 	}
 	if wrapper.DeniedPersons[0].StreetAddress != "P.O. BOX 28360" {
@@ -191,7 +191,7 @@ func TestSearch__NameAndAltName(t *testing.T) {
 
 func TestSearch__Name(t *testing.T) {
 	w := httptest.NewRecorder()
-	req := httptest.NewRequest("GET", "/search?name=AL+ZAWAHIRI&limit=1", nil)
+	req := httptest.NewRequest("GET", "/search?name=Dr+AL+ZAWAHIRI&limit=1", nil)
 
 	router := mux.NewRouter()
 	addSearchRoutes(log.NewNopLogger(), router, sdnSearcher)
@@ -202,7 +202,7 @@ func TestSearch__Name(t *testing.T) {
 		t.Errorf("bogus status code: %d", w.Code)
 	}
 
-	if v := w.Body.String(); !strings.Contains(v, `"match":0.4765`) {
+	if v := w.Body.String(); !strings.Contains(v, `"match":0.873`) {
 		t.Error(v)
 	}
 
@@ -215,6 +215,16 @@ func TestSearch__Name(t *testing.T) {
 	if wrapper.SDNs[0].EntityID != "2676" {
 		t.Errorf("%#v", wrapper.SDNs[0])
 	}
+
+	// directly check searcher.TopSDNs
+	sdns := sdnSearcher.TopSDNs(1, "Dr AL ZAWAHIRI")
+	if len(sdns) != 1 {
+		t.Errorf("got SDNs: %#v", sdns)
+	}
+	if sdns[0].EntityID != "2676" {
+		t.Errorf("%#v", sdns[0])
+	}
+	eql(t, "name match", sdns[0].match, 0.873)
 }
 
 func TestSearch__AltName(t *testing.T) {
@@ -230,7 +240,7 @@ func TestSearch__AltName(t *testing.T) {
 		t.Errorf("bogus status code: %d", w.Code)
 	}
 
-	if v := w.Body.String(); !strings.Contains(v, `"match":0.6367`) {
+	if v := w.Body.String(); !strings.Contains(v, `"match":0.7836`) {
 		t.Error(v)
 	}
 

--- a/cmd/server/search_test.go
+++ b/cmd/server/search_test.go
@@ -177,6 +177,7 @@ func TestSearch_reorderSDNName(t *testing.T) {
 		{"FELIX B. MADURO S.A.", "FELIX B. MADURO S.A."}, // keep .'s in a name
 		{"MADURO MOROS, Nicolas", "Nicolas MADURO MOROS"},
 		{"IBRAHIM, Sadr", "Sadr IBRAHIM"},
+		{"AL ZAWAHIRI, Dr. Ayman", "Dr. Ayman AL ZAWAHIRI"},
 		// Issue 115
 		{"Bush, George W", "George W Bush"},
 		{"RIZO MORENO, Jorge Luis", "Jorge Luis RIZO MORENO"},

--- a/cmd/server/search_test.go
+++ b/cmd/server/search_test.go
@@ -111,27 +111,29 @@ func TestJaroWrinkler(t *testing.T) {
 		s1, s2 string
 		match  float64
 	}{
-		{"wei, zhao", "wei, Zhao", 0.844},
-		{"WEI, Zhao", "WEI, Zhao", 0.889},
-		{"WEI Zhao", "WEI Zhao", 0.875},
+		{"wei, zhao", "wei, Zhao", 0.95},
+		{"WEI, Zhao", "WEI, Zhao", 1.0},
+		{"WEI Zhao", "WEI Zhao", 1.0},
 		{strings.ToLower("WEI Zhao"), precompute("WEI, Zhao"), 1.0},
 		// make sure jaroWrinkler is communative
-		{"jane doe", "jan lahore", 0.483},
-		{"jan lahore", "jane doe", 0.613},
+		{"jane doe", "jan lahore", 0.690},
+		{"jan lahore", "jane doe", 0.690},
 		// close match
-		{"jane doe", "jane doe2", 0.758},
+		{"jane doe", "jane doe2", 0.975},
 		// example cases
-		{"maduro, nicolas", "maduro, nicolas", 0.933},
-		{"maduro moros, nicolas", "maduro moros, nicolas", 0.905},
-		{"maduro moros, nicolas", "nicolas maduro", 0.377},
-		{"nicolas maduro moros", "nicolás maduro", 0.665},
-		{"nicolas, maduro moros", "nicolas maduro", 0.656},
-		{"nicolas, maduro moros", "nicolás maduro", 0.649},
+		{"nicolas maduro", "nicolas maduro", 1.0},
+		{"maduro, nicolas", "maduro, nicolas", 1.0},
+		{"maduro moros, nicolas", "maduro moros, nicolas", 1.0},
+		{"maduro moros, nicolas", "nicolas maduro", 0.512},
+		{"nicolas maduro moros", "nicolás maduro", 0.855},
+		{"nicolas, maduro moros", "nicolas maduro", 0.891},
+		{"nicolas, maduro moros", "nicolás maduro", 0.881},
 	}
 
-	for _, v := range cases {
+	for i := range cases {
+		v := cases[i]
 		// Only need to call chomp on s1, see jaroWrinkler doc
-		eql(t, fmt.Sprintf("%s vs %s", v.s1, v.s2), jaroWrinkler(chomp(v.s1), v.s2), v.match)
+		eql(t, fmt.Sprintf("#%d %s vs %s", i, v.s1, v.s2), jaroWrinkler(chomp(v.s1), v.s2), v.match)
 	}
 }
 
@@ -220,7 +222,7 @@ func TestSearch_liveData(t *testing.T) {
 func TestSearch__topAddressesAddress(t *testing.T) {
 	it := topAddressesAddress("needle")(&Address{address: "needleee"})
 
-	eql(t, "topAddressesAddress", it.weight, 0.712)
+	eql(t, "topAddressesAddress", it.weight, 0.950)
 	if add, ok := it.value.(*Address); !ok || add.address != "needleee" {
 		t.Errorf("got %#v", add)
 	}
@@ -229,7 +231,7 @@ func TestSearch__topAddressesAddress(t *testing.T) {
 func TestSearch__topAddressesCountry(t *testing.T) {
 	it := topAddressesAddress("needle")(&Address{address: "needleee"})
 
-	eql(t, "topAddressesCountry", it.weight, 0.712)
+	eql(t, "topAddressesCountry", it.weight, 0.950)
 	if add, ok := it.value.(*Address); !ok || add.address != "needleee" {
 		t.Errorf("got %#v", add)
 	}
@@ -241,7 +243,7 @@ func TestSearch__multiAddressCompare(t *testing.T) {
 		topAddressesCountry("other"),
 	)(&Address{address: "needlee", country: "other"})
 
-	eql(t, "multiAddressCompare", it.weight, 0.916)
+	eql(t, "multiAddressCompare", it.weight, 0.986)
 	if add, ok := it.value.(*Address); !ok || add.address != "needlee" || add.country != "other" {
 		t.Errorf("got %#v", add)
 	}
@@ -369,7 +371,7 @@ func TestSearch__FindSDN(t *testing.T) {
 }
 
 func TestSearch__TopSDNs(t *testing.T) {
-	sdns := sdnSearcher.TopSDNs(1, "AL ZAWAHIRI")
+	sdns := sdnSearcher.TopSDNs(1, "Ayman ZAWAHIRI")
 	if len(sdns) == 0 {
 		t.Fatal("empty SDNs")
 	}

--- a/cmd/server/search_test.go
+++ b/cmd/server/search_test.go
@@ -209,7 +209,8 @@ func TestSearch_liveData(t *testing.T) {
 		name  string
 		match float64 // top match %
 	}{
-		{"Nicolas MADURO", 0.821},
+		{"Nicolas MADURO", 0.944},
+		{"nicolas maduro", 0.944},
 	}
 	for i := range cases {
 		sdns := searcher.TopSDNs(1, cases[i].name)


### PR DESCRIPTION

We should favor strong single word matches to reflect higher overall
match percentages. In short this is useful for matching names like:

    Nicolas MADURO

against an SDN entity like:

    MADURO MOROS, Nicolas

People often won't specify middle names (or multiple first/last
names), so when positive matches are identified we should keep the
overall match percentages high.

Issue: #141