### PR TITLE
cmd/server: remove 'logger != nil' checks

### DIFF
--- a/cmd/server/download_handler.go
+++ b/cmd/server/download_handler.go
@@ -19,18 +19,15 @@ const (
 // manualRefreshHandler will register an endpoint on the admin server OFAC data refresh endpoint
 func manualRefreshHandler(logger log.Logger, searcher *searcher, downloadRepo downloadRepository) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		if logger != nil {
-			logger.Log("main", "admin: refreshing OFAC data")
-		}
+		logger.Log("main", "admin: refreshing OFAC data")
 		if stats, err := searcher.refreshData(""); err != nil {
-			if logger != nil {
-				logger.Log("main", fmt.Sprintf("ERROR: admin: problem refreshing OFAC data: %v", err))
-			}
+			logger.Log("main", fmt.Sprintf("ERROR: admin: problem refreshing OFAC data: %v", err))
 			w.WriteHeader(http.StatusInternalServerError)
 		} else {
-			if logger != nil {
-				logger.Log("main", fmt.Sprintf("admin: finished OFAC data refresh - Addresses=%d AltNames=%d SDNs=%d DeniedPersons=%d", stats.Addresses, stats.Alts, stats.SDNs, stats.DeniedPersons))
-			}
+			logger.Log("main",
+				fmt.Sprintf("admin: finished OFAC data refresh - Addresses=%d AltNames=%d SDNs=%d DeniedPersons=%d",
+					stats.Addresses, stats.Alts, stats.SDNs, stats.DeniedPersons))
+
 			downloadRepo.recordStats(stats)
 
 			w.WriteHeader(http.StatusOK)

--- a/cmd/server/search_handlers.go
+++ b/cmd/server/search_handlers.go
@@ -53,45 +53,35 @@ func search(logger log.Logger, searcher *searcher) http.HandlerFunc {
 
 		// Search over all fields
 		if q := strings.TrimSpace(r.URL.Query().Get("q")); q != "" {
-			if logger != nil {
-				logger.Log("search", fmt.Sprintf("searching all names and address for %s", q), "requestID", requestID, "userID", userID)
-			}
+			logger.Log("search", fmt.Sprintf("searching all names and address for %s", q), "requestID", requestID, "userID", userID)
 			searchViaQ(logger, searcher, q)(w, r)
 			return
 		}
 
 		// Search by ID (found in an SDN's Remarks property)
 		if id := strings.TrimSpace(r.URL.Query().Get("id")); id != "" {
-			if logger != nil {
-				logger.Log("search", fmt.Sprintf("searching SDNs by remarks ID for %s", id))
-			}
+			logger.Log("search", fmt.Sprintf("searching SDNs by remarks ID for %s", id))
 			searchByRemarksID(logger, searcher, id)(w, r)
 			return
 		}
 
 		// Search by Name
 		if name := strings.TrimSpace(r.URL.Query().Get("name")); name != "" {
-			if logger != nil {
-				logger.Log("search", fmt.Sprintf("searching SDN names for %s", name), "requestID", requestID, "userID", userID)
-			}
+			logger.Log("search", fmt.Sprintf("searching SDN names for %s", name), "requestID", requestID, "userID", userID)
 			searchByName(logger, searcher, name)(w, r)
 			return
 		}
 
 		// Search by Alt Name
 		if alt := strings.TrimSpace(r.URL.Query().Get("altName")); alt != "" {
-			if logger != nil {
-				logger.Log("search", fmt.Sprintf("searching SDN alt names for %s", alt), "requestID", requestID, "userID", userID)
-			}
+			logger.Log("search", fmt.Sprintf("searching SDN alt names for %s", alt), "requestID", requestID, "userID", userID)
 			searchByAltName(logger, searcher, alt)(w, r)
 			return
 		}
 
 		// Search Addresses
 		if req := readAddressSearchRequest(r.URL); !req.empty() {
-			if logger != nil {
-				logger.Log("search", fmt.Sprintf("searching address for %#v", req), "requestID", requestID, "userID", userID)
-			}
+			logger.Log("search", fmt.Sprintf("searching address for %#v", req), "requestID", requestID, "userID", userID)
 			searchByAddress(logger, searcher, req)(w, r)
 			return
 		}


### PR DESCRIPTION
We already specify a logger in tests so these are wasteful.