### PR TITLE
cmd/server: return the oldest refresh time for our data in search results

### DIFF
--- a/client/api/openapi.yaml
+++ b/client/api/openapi.yaml
@@ -1398,6 +1398,7 @@ components:
           state: TX
           effectiveDate: 06/15/2016
           expirationDate: 06/15/2025
+        refreshedAt: 2000-01-23T04:56:07.000+00:00
       properties:
         SDNs:
           items:
@@ -1415,6 +1416,9 @@ components:
           items:
             $ref: '#/components/schemas/DPL'
           type: array
+        refreshedAt:
+          format: date-time
+          type: string
     Watch:
       description: Customer or Company watch
       example:

--- a/client/docs/Search.md
+++ b/client/docs/Search.md
@@ -8,6 +8,7 @@ Name | Type | Description | Notes
 **AltNames** | [**[]Alt**](Alt.md) |  | [optional] 
 **Addresses** | [**[]Address**](Address.md) |  | [optional] 
 **DeniedPersons** | [**[]Dpl**](DPL.md) |  | [optional] 
+**RefreshedAt** | [**time.Time**](time.Time.md) |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/client/model_search.go
+++ b/client/model_search.go
@@ -9,10 +9,15 @@
 
 package openapi
 
+import (
+	"time"
+)
+
 // Search results containing SDNs, alternate names and/or addreses
 type Search struct {
 	SDNs          []Sdn     `json:"SDNs,omitempty"`
 	AltNames      []Alt     `json:"altNames,omitempty"`
 	Addresses     []Address `json:"addresses,omitempty"`
 	DeniedPersons []Dpl     `json:"deniedPersons,omitempty"`
+	RefreshedAt   time.Time `json:"refreshedAt,omitempty"`
 }

--- a/cmd/server/download_test.go
+++ b/cmd/server/download_test.go
@@ -60,7 +60,7 @@ func TestDownload_record(t *testing.T) {
 	t.Parallel()
 
 	check := func(t *testing.T, repo *sqliteDownloadRepository) {
-		stats := &downloadStats{1, 12, 42, 13}
+		stats := &downloadStats{SDNs: 1, Alts: 12, Addresses: 42, DeniedPersons: 13}
 		if err := repo.recordStats(stats); err != nil {
 			t.Fatal(err)
 		}
@@ -103,7 +103,7 @@ func TestDownload_route(t *testing.T) {
 		req := httptest.NewRequest("GET", "/downloads", nil)
 		req.Header.Set("x-user-id", "test")
 
-		repo.recordStats(&downloadStats{1, 421, 1511, 731})
+		repo.recordStats(&downloadStats{SDNs: 1, Alts: 421, Addresses: 1511, DeniedPersons: 731})
 
 		router := mux.NewRouter()
 		addDownloadRoutes(nil, router, repo)

--- a/cmd/server/search.go
+++ b/cmd/server/search.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 	"unicode"
 
 	"github.com/moov-io/ofac"
@@ -34,11 +35,12 @@ var (
 // searcher holds precomputed data for each object available to search against.
 // This data comes from various US Federal agencies, such as: OFAC and BIS
 type searcher struct {
-	SDNs         []*SDN
-	Addresses    []*Address
-	Alts         []*Alt
-	DPs          []*DP
-	sync.RWMutex // protects all above fields
+	SDNs            []*SDN
+	Addresses       []*Address
+	Alts            []*Alt
+	DPs             []*DP
+	lastRefreshedAt time.Time
+	sync.RWMutex    // protects all above fields
 
 	logger log.Logger
 }

--- a/cmd/server/search_handlers.go
+++ b/cmd/server/search_handlers.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	moovhttp "github.com/moov-io/base/http"
 
@@ -96,6 +97,7 @@ type searchResponse struct {
 	AltNames      []Alt     `json:"altNames"`
 	Addresses     []Address `json:"addresses"`
 	DeniedPersons []DP      `json:"deniedPersons"`
+	RefreshedAt   time.Time `json:"refreshedAt"`
 }
 
 func searchByAddress(logger log.Logger, searcher *searcher, req addressSearchRequest) http.HandlerFunc {
@@ -105,7 +107,9 @@ func searchByAddress(logger log.Logger, searcher *searcher, req addressSearchReq
 			return
 		}
 
-		var resp searchResponse
+		resp := searchResponse{
+			RefreshedAt: searcher.lastRefreshedAt,
+		}
 		limit := extractSearchLimit(r)
 
 		var compares []func(*Address) *item
@@ -164,6 +168,7 @@ func searchViaQ(logger log.Logger, searcher *searcher, name string) http.Handler
 			AltNames:      searcher.TopAltNames(limit, name),
 			Addresses:     searcher.TopAddresses(limit, name),
 			DeniedPersons: searcher.TopDPs(limit, name),
+			RefreshedAt:   searcher.lastRefreshedAt,
 		}
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		w.WriteHeader(http.StatusOK)
@@ -187,7 +192,7 @@ func searchByRemarksID(logger log.Logger, searcher *searcher, id string) http.Ha
 
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		w.WriteHeader(http.StatusOK)
-		if err := json.NewEncoder(w).Encode(&searchResponse{SDNs: sdns}); err != nil {
+		if err := json.NewEncoder(w).Encode(&searchResponse{SDNs: sdns, RefreshedAt: searcher.lastRefreshedAt}); err != nil {
 			moovhttp.Problem(w, err)
 			return
 		}
@@ -208,7 +213,7 @@ func searchByName(logger log.Logger, searcher *searcher, nameSlug string) http.H
 
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		w.WriteHeader(http.StatusOK)
-		if err := json.NewEncoder(w).Encode(&searchResponse{SDNs: sdns}); err != nil {
+		if err := json.NewEncoder(w).Encode(&searchResponse{SDNs: sdns, RefreshedAt: searcher.lastRefreshedAt}); err != nil {
 			moovhttp.Problem(w, err)
 			return
 		}
@@ -227,7 +232,7 @@ func searchByAltName(logger log.Logger, searcher *searcher, altSlug string) http
 
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		w.WriteHeader(http.StatusOK)
-		if err := json.NewEncoder(w).Encode(&searchResponse{AltNames: alts}); err != nil {
+		if err := json.NewEncoder(w).Encode(&searchResponse{AltNames: alts, RefreshedAt: searcher.lastRefreshedAt}); err != nil {
 			moovhttp.Problem(w, err)
 			return
 		}

--- a/cmd/server/search_handlers.go
+++ b/cmd/server/search_handlers.go
@@ -163,19 +163,15 @@ func searchViaQ(logger log.Logger, searcher *searcher, name string) http.Handler
 		sdns = filterSDNs(sdns, buildFilterRequest(r.URL))
 
 		// Build our big response object
-		response := &searchResponse{
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(&searchResponse{
 			SDNs:          sdns,
 			AltNames:      searcher.TopAltNames(limit, name),
 			Addresses:     searcher.TopAddresses(limit, name),
 			DeniedPersons: searcher.TopDPs(limit, name),
 			RefreshedAt:   searcher.lastRefreshedAt,
-		}
-		w.Header().Set("Content-Type", "application/json; charset=utf-8")
-		w.WriteHeader(http.StatusOK)
-		if err := json.NewEncoder(w).Encode(response); err != nil {
-			moovhttp.Problem(w, err)
-			return
-		}
+		})
 	}
 }
 
@@ -192,10 +188,10 @@ func searchByRemarksID(logger log.Logger, searcher *searcher, id string) http.Ha
 
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		w.WriteHeader(http.StatusOK)
-		if err := json.NewEncoder(w).Encode(&searchResponse{SDNs: sdns, RefreshedAt: searcher.lastRefreshedAt}); err != nil {
-			moovhttp.Problem(w, err)
-			return
-		}
+		json.NewEncoder(w).Encode(&searchResponse{
+			SDNs:        sdns,
+			RefreshedAt: searcher.lastRefreshedAt,
+		})
 	}
 }
 
@@ -213,10 +209,10 @@ func searchByName(logger log.Logger, searcher *searcher, nameSlug string) http.H
 
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		w.WriteHeader(http.StatusOK)
-		if err := json.NewEncoder(w).Encode(&searchResponse{SDNs: sdns, RefreshedAt: searcher.lastRefreshedAt}); err != nil {
-			moovhttp.Problem(w, err)
-			return
-		}
+		json.NewEncoder(w).Encode(&searchResponse{
+			SDNs:        sdns,
+			RefreshedAt: searcher.lastRefreshedAt,
+		})
 	}
 }
 
@@ -232,9 +228,9 @@ func searchByAltName(logger log.Logger, searcher *searcher, altSlug string) http
 
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		w.WriteHeader(http.StatusOK)
-		if err := json.NewEncoder(w).Encode(&searchResponse{AltNames: alts, RefreshedAt: searcher.lastRefreshedAt}); err != nil {
-			moovhttp.Problem(w, err)
-			return
-		}
+		json.NewEncoder(w).Encode(&searchResponse{
+			AltNames:    alts,
+			RefreshedAt: searcher.lastRefreshedAt,
+		})
 	}
 }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -993,6 +993,10 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/DPL'
+        refreshedAt:
+          type: string
+          format: date-time
+          example: 2006-01-02T15:04:05Z07:00
     Watch:
       description: Customer or Company watch
       properties:


### PR DESCRIPTION

This was requested as part of an audit of OFAC, which helps clients to
know how stale the data being searched on is.