### PR TITLE
Search api lifecycle

### DIFF
--- a/webui/src/Components.js
+++ b/webui/src/Components.js
@@ -1,7 +1,9 @@
 // import React from "react";
 import styled from "styled-components/macro"; // eslint-disable-line no-unused-vars
 import MContainer from "@material-ui/core/Container";
+import MCircularProgress from "@material-ui/core/CircularProgress";
 
+export const Spinner = MCircularProgress;
 export const Container = styled(MContainer)``;
 export const Section = styled.section`
   border: 1px solid #eee;

--- a/webui/src/Form/index.js
+++ b/webui/src/Form/index.js
@@ -7,7 +7,7 @@ import * as C from "../Components";
 import Select from "./Select";
 import TextInput from "./TextInput";
 import Slider from "./Slider";
-import { countryOptionData, listOptionData, programOptionData } from "../data";
+import { countryOptionData, listOptionData } from "../data";
 import { parseQueryString } from "utils";
 import { useTypeOptions, useProgramOptions } from "./options";
 

--- a/webui/src/Form/index.js
+++ b/webui/src/Form/index.js
@@ -47,7 +47,7 @@ const initialValues = {
   zip: "",
   limit: 10,
   q: "",
-  type: "",
+  sdnType: "",
   program: ""
   // disabled ///////////
   // idNumber: "",
@@ -132,9 +132,9 @@ export default ({ onSubmit, onReset }) => {
               <Cell>
                 <Select
                   label="Type"
-                  id="type"
-                  value={values["type"]}
-                  onChange={handleChange("type")}
+                  id="sdnType"
+                  value={values["sdnType"]}
+                  onChange={handleChange("sdnType")}
                   options={typeOptionValues}
                 />
               </Cell>
@@ -221,28 +221,6 @@ export default ({ onSubmit, onReset }) => {
           </Cell>
           {false && (
             <>
-              <Cell>
-                <Select
-                  disabled={true}
-                  label="Program"
-                  id="program"
-                  multiple
-                  value={values["program"]}
-                  onChange={handleChange("program")}
-                  options={programOptionData}
-                />
-              </Cell>
-              <Cell>
-                <Select
-                  disabled={true}
-                  label="Type"
-                  id="type"
-                  value={values["type"]}
-                  onChange={handleChange("type")}
-                  options={typeOptionValues}
-                />
-              </Cell>
-
               <Cell>
                 <Select
                   disabled={true}

--- a/webui/src/Results/Addresses.js
+++ b/webui/src/Results/Addresses.js
@@ -39,7 +39,7 @@ export const Addresses = ({ data }) => {
   );
 };
 
-export const Address = ({ data }) => {
+export const Address = ({ data, displayId = "entityID" }) => {
   return (
     <div
       css={`
@@ -64,7 +64,7 @@ export const Address = ({ data }) => {
           }
         `}
       >
-        <div>{R.toLower(data.entityID)}</div>
+        <div>{R.toLower(data[displayId])}</div>
         <div>{R.toLower(data.address)}</div>
         <div>{R.toLower(data.cityStateProvincePostalCode)}</div>
         <div>{R.toLower(data.country)}</div>

--- a/webui/src/Results/AltNames.js
+++ b/webui/src/Results/AltNames.js
@@ -32,7 +32,7 @@ export const AltNames = ({ data }) => {
   );
 };
 
-export const AltName = ({ data }) => {
+export const AltName = ({ data, displayId = "entityID" }) => {
   return (
     <div
       css={`
@@ -56,7 +56,7 @@ export const AltName = ({ data }) => {
           }
         `}
       >
-        <div>{data.entityID}</div>
+        <div>{data[displayId]}</div>
         <div>{data.alternateName}</div>
         <div
           css={`

--- a/webui/src/Results/SDNDetails.js
+++ b/webui/src/Results/SDNDetails.js
@@ -18,7 +18,7 @@ const Addresses = ({ data }) => {
       <C.SectionTitle>Addresses</C.SectionTitle>
       <AddressHeader withMatch={false} />
       {data.map(a => (
-        <Address key={a.addressID} data={a} />
+        <Address key={a.addressID} data={a} displayId="addressID" />
       ))}
     </div>
   );
@@ -36,7 +36,7 @@ const Alternates = ({ data }) => {
       <C.SectionTitle>Alternate Names</C.SectionTitle>
       <AlternatesHeader withMatch={false} />
       {data.map(a => (
-        <AltName key={a.alternateID} data={a} />
+        <AltName key={a.alternateID} data={a} displayId="alternateID" />
       ))}
     </div>
   );

--- a/webui/src/Results/index.js
+++ b/webui/src/Results/index.js
@@ -7,16 +7,29 @@ import { Addresses } from "./Addresses";
 import { DeniedPersons } from "./DeniedPersons";
 import { isNilOrEmpty } from "utils";
 
-const Results = ({ data }) => {
-  if (isNilOrEmpty(data)) return null;
+export default ({ data }) => {
+  const { loading, error, results } = data;
+  if (loading)
+    return (
+      <C.Container>
+        <div
+          css={`
+            display: flex;
+            justify-content: center;
+          `}
+        >
+          <C.Spinner />
+        </div>
+      </C.Container>
+    );
+  if (error) return <C.Container>ERROR: {error.message}</C.Container>;
+  if (isNilOrEmpty(results)) return null;
   return (
     <C.Container>
-      <SDNS data={data.SDNs} />
-      <AltNames data={data.altNames} />
-      <Addresses data={data.addresses} />
-      <DeniedPersons data={data.deniedPersons} />
+      <SDNS data={results.SDNs} />
+      <AltNames data={results.altNames} />
+      <Addresses data={results.addresses} />
+      <DeniedPersons data={results.deniedPersons} />
     </C.Container>
   );
 };
-
-export default Results;

--- a/webui/src/api.js
+++ b/webui/src/api.js
@@ -1,24 +1,13 @@
-export const search = async qs => {
-  const r = await fetch(`/search?${qs}`);
-  return await r.json();
+const apiGet = async path => {
+  const response = await fetch(path);
+  const payload = await response.json();
+  if (!response.ok) throw new Error(payload.error);
+  return payload;
 };
 
-export const getSDNAlts = async sdnId => {
-  const r = await fetch(`/sdn/${sdnId}/alts`);
-  return await r.json();
-};
+export const search = async qs => apiGet(`/search?${qs}`);
 
-export const getSDNAddresses = async sdnId => {
-  const r = await fetch(`/sdn/${sdnId}/addresses`);
-  return await r.json();
-};
-
-export const getSDNTypes = async qs => {
-  const r = await fetch(`/ui/values/sdnType`);
-  return await r.json();
-};
-
-export const getPrograms = async qs => {
-  const r = await fetch(`/ui/values/program`);
-  return await r.json();
-};
+export const getSDNAlts = async sdnId => (await fetch(`/sdn/${sdnId}/alts`)).json();
+export const getSDNAddresses = async sdnId => (await fetch(`/sdn/${sdnId}/addresses`)).json();
+export const getSDNTypes = async qs => (await fetch(`/ui/values/sdnType`)).json();
+export const getPrograms = async qs => (await fetch(`/ui/values/program`)).json();


### PR DESCRIPTION
Includes:

- fix the parameter name passed to the search api `type` => `sdnType`
- polish the search interaction with a loading state and error display
- when expanding SDN results, show the `addressID` / `alternateID` rather than duplicate the parent `entityID` 