### PR TITLE
cmd/server: never allow jaroWinkler to return NaN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ BUG FIXES
 
 - attempt retries when downloading files
 - download: return after successful download
-- cmd/server: search: fix match percents after jaroWrinkler change
+- cmd/server: search: fix match percents after jaroWinkler change
 - cmd/server: when reordering names handle multiple first or last names
 
 ADDITIONS

--- a/cmd/server/issue115_test.go
+++ b/cmd/server/issue115_test.go
@@ -13,10 +13,10 @@ import (
 )
 
 func TestIssue115__TopSDNs(t *testing.T) {
-	score := jaroWrinkler("georgehabbash", "georgebush")
-	eql(t, "george bush jaroWrinkler", score, 0.896)
+	score := jaroWinkler("georgehabbash", "georgebush")
+	eql(t, "george bush jaroWinkler", score, 0.896)
 
-	score = jaroWrinkler("g", "geoergebush")
+	score = jaroWinkler("g", "geoergebush")
 	eql(t, "g vs geoergebush", score, 0.697)
 
 	s := &searcher{logger: log.NewNopLogger()}

--- a/cmd/server/search.go
+++ b/cmd/server/search.go
@@ -69,7 +69,7 @@ var (
 		return func(add *Address) *item {
 			return &item{
 				value:  add,
-				weight: jaroWrinkler(add.address, precompute(needleAddr)),
+				weight: jaroWinkler(add.address, precompute(needleAddr)),
 			}
 		}
 	}
@@ -81,7 +81,7 @@ var (
 		return func(add *Address) *item {
 			return &item{
 				value:  add,
-				weight: jaroWrinkler(add.citystate, precompute(needleCityState)),
+				weight: jaroWinkler(add.citystate, precompute(needleCityState)),
 			}
 		}
 	}
@@ -91,7 +91,7 @@ var (
 		return func(add *Address) *item {
 			return &item{
 				value:  add,
-				weight: jaroWrinkler(add.country, precompute(needleCountry)),
+				weight: jaroWinkler(add.country, precompute(needleCountry)),
 			}
 		}
 	}
@@ -179,7 +179,7 @@ func (s *searcher) TopAltNames(limit int, alt string) []Alt {
 	for i := range s.Alts {
 		xs.add(&item{
 			value:  s.Alts[i],
-			weight: jaroWrinkler(s.Alts[i].name, alt),
+			weight: jaroWinkler(s.Alts[i].name, alt),
 		})
 	}
 
@@ -251,7 +251,7 @@ func (s *searcher) TopSDNs(limit int, name string) []SDN {
 	for i := range s.SDNs {
 		xs.add(&item{
 			value:  s.SDNs[i],
-			weight: jaroWrinkler(s.SDNs[i].name, name),
+			weight: jaroWinkler(s.SDNs[i].name, name),
 		})
 	}
 
@@ -284,7 +284,7 @@ func (s *searcher) TopDPs(limit int, name string) []DP {
 	for _, dp := range s.DPs {
 		xs.add(&item{
 			value:  dp,
-			weight: jaroWrinkler(dp.name, name),
+			weight: jaroWinkler(dp.name, name),
 		})
 	}
 
@@ -498,7 +498,7 @@ func extractSearchLimit(r *http.Request) int {
 	return limit
 }
 
-// jaroWrinkler runs the similarly named algorithm over the two input strings and weighs the score
+// jaroWinkler runs the similarly named algorithm over the two input strings and weighs the score
 // against the string lengths. We do this to tone down equality among strings whose lengths vary by
 // several characters.
 //
@@ -506,7 +506,7 @@ func extractSearchLimit(r *http.Request) int {
 //
 // Right now s1 is assumes to have been passed through `chomp(..)` already and so this
 // func only calls `chomp` for s2.
-func jaroWrinkler(s1, s2 string) float64 {
+func jaroWinkler(s1, s2 string) float64 {
 	maxMatch := func(word string, parts []string) float64 {
 		if len(parts) == 0 {
 			return 0.0

--- a/cmd/server/search.go
+++ b/cmd/server/search.go
@@ -520,8 +520,12 @@ func jaroWinkler(s1, s2 string) float64 {
 		return max
 	}
 
-	var max float64
 	s1Parts, s2Parts := strings.Fields(s1), strings.Fields(chomp(s2))
+	if len(s1Parts) == 0 || len(s2Parts) == 0 {
+		return 0.0 // avoid returning NaN later on
+	}
+
+	var max float64
 	for i := range s1Parts {
 		score := maxMatch(s1Parts[i], s2Parts)
 		if score > 0.99 {

--- a/cmd/server/search_test.go
+++ b/cmd/server/search_test.go
@@ -149,6 +149,14 @@ func TestJaroWinkler(t *testing.T) {
 	}
 }
 
+func TestJaroWinklerErr(t *testing.T) {
+	v := jaroWinkler("", "hello")
+	eql(t, "NaN #1", v, 0.0)
+
+	v = jaroWinkler("hello", "")
+	eql(t, "NaN #1", v, 0.0)
+}
+
 func eql(t *testing.T, desc string, x, y float64) {
 	t.Helper()
 	if math.IsNaN(x) || math.IsNaN(y) {

--- a/cmd/server/search_test.go
+++ b/cmd/server/search_test.go
@@ -118,7 +118,7 @@ var (
 	}
 )
 
-func TestJaroWrinkler(t *testing.T) {
+func TestJaroWinkler(t *testing.T) {
 	cases := []struct {
 		s1, s2 string
 		match  float64
@@ -127,7 +127,7 @@ func TestJaroWrinkler(t *testing.T) {
 		{"WEI, Zhao", "WEI, Zhao", 1.0},
 		{"WEI Zhao", "WEI Zhao", 1.0},
 		{strings.ToLower("WEI Zhao"), precompute("WEI, Zhao"), 1.0},
-		// make sure jaroWrinkler is communative
+		// make sure jaroWinkler is communative
 		{"jane doe", "jan lahore", 0.690},
 		{"jan lahore", "jane doe", 0.690},
 		// close match
@@ -144,13 +144,16 @@ func TestJaroWrinkler(t *testing.T) {
 
 	for i := range cases {
 		v := cases[i]
-		// Only need to call chomp on s1, see jaroWrinkler doc
-		eql(t, fmt.Sprintf("#%d %s vs %s", i, v.s1, v.s2), jaroWrinkler(chomp(v.s1), v.s2), v.match)
+		// Only need to call chomp on s1, see jaroWinkler doc
+		eql(t, fmt.Sprintf("#%d %s vs %s", i, v.s1, v.s2), jaroWinkler(chomp(v.s1), v.s2), v.match)
 	}
 }
 
 func eql(t *testing.T, desc string, x, y float64) {
 	t.Helper()
+	if math.IsNaN(x) || math.IsNaN(y) {
+		t.Fatalf("%s: x=%.2f y=%.2f", desc, x, y)
+	}
 	if math.Abs(x-y) > 0.01 {
 		t.Errorf("%s: %.3f != %.3f", desc, x, y)
 	}


### PR DESCRIPTION
Found this during https://github.com/moov-io/ofac/pull/148 testing. Some addresses from the SDN file have partial data (missing address, city/state/providence, or zip fields).