### PR TITLE
WIP: cmd/server: return the maximum between soundex and jaro-winkler in search

### DIFF
--- a/cmd/server/issue115_test.go
+++ b/cmd/server/issue115_test.go
@@ -27,12 +27,12 @@ func TestIssue115__TopSDNs(t *testing.T) {
 	// was 89.6% match
 	s.SDNs = precomputeSDNs([]*ofac.SDN{{EntityID: "2680", SDNName: "HABBASH, George", SDNType: "INDIVIDUAL"}})
 	out := s.TopSDNs(1, "george bush")
-	eql(t, "issue115: top SDN 2680", out[0].match, 0.896)
+	eql(t, "issue115: top SDN 2680", out[0].match, 1.0)
 
 	// was 88.3% match
 	s.SDNs = precomputeSDNs([]*ofac.SDN{{EntityID: "9432", SDNName: "CHIWESHE, George", SDNType: "INDIVIDUAL"}})
 	out = s.TopSDNs(1, "george bush")
-	eql(t, "issue115: top SDN 18996", out[0].match, 0.849)
+	eql(t, "issue115: top SDN 18996", out[0].match, 0.883)
 
 	// another example
 	s.SDNs = precomputeSDNs([]*ofac.SDN{{EntityID: "0", SDNName: "Bush, George W", SDNType: "INDIVIDUAL"}})
@@ -41,7 +41,7 @@ func TestIssue115__TopSDNs(t *testing.T) {
 	}
 
 	out = s.TopSDNs(1, "george bush")
-	eql(t, "issue115: top SDN 0", out[0].match, 0.942)
+	eql(t, "issue115: top SDN 0", out[0].match, 1.0)
 
 	out = s.TopSDNs(1, "george w bush")
 	eql(t, "issue115: top SDN 0", out[0].match, 1.0)

--- a/cmd/server/search_handlers_test.go
+++ b/cmd/server/search_handlers_test.go
@@ -30,7 +30,7 @@ func TestSearch__Address(t *testing.T) {
 		t.Errorf("bogus status code: %d", w.Code)
 	}
 
-	if v := w.Body.String(); !strings.Contains(v, `"match":0.9229`) {
+	if v := w.Body.String(); !strings.Contains(v, `"match":1`) {
 		t.Errorf("%#v", v)
 	}
 
@@ -86,7 +86,7 @@ func TestSearch__AddressMulti(t *testing.T) {
 		t.Errorf("bogus status code: %d", w.Code)
 	}
 
-	if v := w.Body.String(); !strings.Contains(v, `"match":0.945`) {
+	if v := w.Body.String(); !strings.Contains(v, `"match":1`) {
 		t.Errorf("%#v", v)
 	}
 }
@@ -104,7 +104,7 @@ func TestSearch__AddressProvidence(t *testing.T) {
 		t.Errorf("bogus status code: %d", w.Code)
 	}
 
-	if v := w.Body.String(); !strings.Contains(v, `"match":0.963`) {
+	if v := w.Body.String(); !strings.Contains(v, `"match":1`) {
 		t.Errorf("%#v", v)
 	}
 }
@@ -122,7 +122,7 @@ func TestSearch__AddressCity(t *testing.T) {
 		t.Errorf("bogus status code: %d", w.Code)
 	}
 
-	if v := w.Body.String(); !strings.Contains(v, `"match":0.963`) {
+	if v := w.Body.String(); !strings.Contains(v, `"match":1`) {
 		t.Errorf("%#v", v)
 	}
 }
@@ -140,7 +140,7 @@ func TestSearch__AddressState(t *testing.T) {
 		t.Errorf("bogus status code: %d", w.Code)
 	}
 
-	if v := w.Body.String(); !strings.Contains(v, `"match":0.963`) {
+	if v := w.Body.String(); !strings.Contains(v, `"match":1`) {
 		t.Errorf("%#v", v)
 	}
 }
@@ -178,7 +178,7 @@ func TestSearch__NameAndAltName(t *testing.T) {
 	if wrapper.SDNs[0].EntityID != "2681" {
 		t.Errorf("%#v", wrapper.SDNs[0])
 	}
-	if wrapper.AltNames[0].EntityID != "4691" {
+	if wrapper.AltNames[0].EntityID != "559" {
 		t.Errorf("%#v", wrapper.AltNames[0].EntityID)
 	}
 	if wrapper.Addresses[0].EntityID != "173" {

--- a/cmd/server/search_test.go
+++ b/cmd/server/search_test.go
@@ -247,7 +247,7 @@ func TestSearch_liveData(t *testing.T) {
 func TestSearch__topAddressesAddress(t *testing.T) {
 	it := topAddressesAddress("needle")(&Address{address: "needleee"})
 
-	eql(t, "topAddressesAddress", it.weight, 0.950)
+	eql(t, "topAddressesAddress", it.weight, 1.0)
 	if add, ok := it.value.(*Address); !ok || add.address != "needleee" {
 		t.Errorf("got %#v", add)
 	}
@@ -256,7 +256,7 @@ func TestSearch__topAddressesAddress(t *testing.T) {
 func TestSearch__topAddressesCountry(t *testing.T) {
 	it := topAddressesAddress("needle")(&Address{address: "needleee"})
 
-	eql(t, "topAddressesCountry", it.weight, 0.950)
+	eql(t, "topAddressesCountry", it.weight, 1.0)
 	if add, ok := it.value.(*Address); !ok || add.address != "needleee" {
 		t.Errorf("got %#v", add)
 	}
@@ -268,7 +268,7 @@ func TestSearch__multiAddressCompare(t *testing.T) {
 		topAddressesCountry("other"),
 	)(&Address{address: "needlee", country: "other"})
 
-	eql(t, "multiAddressCompare", it.weight, 0.986)
+	eql(t, "multiAddressCompare", it.weight, 1.0)
 	if add, ok := it.value.(*Address); !ok || add.address != "needlee" || add.country != "other" {
 		t.Errorf("got %#v", add)
 	}


### PR DESCRIPTION
This change will return the maximum match percentage between two strings after running jaro-winkler or soundex (and then jaro-winkler). 

Initially these search results seem to create more false positive search results, so I'm hesitant to merge this PR. 

`george bush` should not match 100% with `George HABBASH`, but soundex+jaro returns that high match result, which is too touchy. 

Fixes: https://github.com/moov-io/ofac/issues/150