### PR TITLE
cmd/ofaccheck: initial setup of a cli tool for batch searches

### DIFF
--- a/cmd/internal/client.go
+++ b/cmd/internal/client.go
@@ -1,0 +1,50 @@
+package internal
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/moov-io/base/http/bind"
+	"github.com/moov-io/ofac"
+	moov "github.com/moov-io/ofac/client"
+)
+
+const (
+	DefaultApiAddress = "https://api.moov.io"
+)
+
+// addr reads flagApiAddress and flagLocal to compute the HTTP address used for connecting with OFAC.
+func addr(address string, local bool) string {
+	if local {
+		// If '-local and -address <foo>' use <foo>
+		if address != DefaultApiAddress {
+			return strings.TrimSuffix(address, "/")
+		} else {
+			return "http://localhost" + bind.HTTP("ofac")
+		}
+	} else {
+		address = strings.TrimSuffix(address, "/")
+		// -address isn't changed, so assume Moov's API (needs extra path added)
+		if address == DefaultApiAddress {
+			return address + "/v1/ofac"
+		}
+		return address
+	}
+}
+
+func Config(address string, local bool) *moov.Configuration {
+	conf := moov.NewConfiguration()
+	conf.BasePath = addr(address, local)
+
+	conf.UserAgent = fmt.Sprintf("moov/ofactest:%s", ofac.Version)
+	conf.HTTPClient = &http.Client{
+		Timeout: 10 * time.Second,
+		Transport: &http.Transport{
+			IdleConnTimeout: 1 * time.Minute,
+		},
+	}
+
+	return conf
+}

--- a/cmd/internal/client_test.go
+++ b/cmd/internal/client_test.go
@@ -2,13 +2,13 @@
 // Use of this source code is governed by an Apache License
 // license that can be found in the LICENSE file.
 
-package main
+package internal
 
 import (
 	"testing"
 )
 
-func TestOFAC_getBasePath(t *testing.T) {
+func TestOFAC_addr(t *testing.T) {
 	cases := []struct {
 		addr     string
 		local    bool
@@ -16,11 +16,11 @@ func TestOFAC_getBasePath(t *testing.T) {
 	}{
 		{"http://localhost:8084", false, "http://localhost:8084"},
 		{"http://localhost:8084/", false, "http://localhost:8084"},
-		{defaultApiAddress, true, "http://localhost:8084"},
-		{defaultApiAddress, false, defaultApiAddress + "/v1/ofac"},
+		{DefaultApiAddress, true, "http://localhost:8084"},
+		{DefaultApiAddress, false, DefaultApiAddress + "/v1/ofac"},
 	}
 	for i := range cases {
-		got := getBasePath(cases[i].addr, cases[i].local)
+		got := addr(cases[i].addr, cases[i].local)
 		if got != cases[i].expected {
 			t.Errorf("idx=%d got=%q expected=%q", i, got, cases[i].expected)
 		}

--- a/cmd/ofaccheck/main.go
+++ b/cmd/ofaccheck/main.go
@@ -1,0 +1,211 @@
+// Copyright 2019 The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+// ofaccheck is a cli tool used for testing batches of names against the OFAC service.
+//
+// With no arguments the contaier runs tests against the production API.
+//
+// TODO(adam): more docs
+//
+// ofaccheck is not a stable tool. Please contact Moov developers if you intend to use this tool,
+// otherwise we might change the tool (or remove it) without notice.
+package main
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/antihax/optional"
+	"github.com/moov-io/ofac"
+	moov "github.com/moov-io/ofac/client"
+	"github.com/moov-io/ofac/cmd/internal"
+
+	"go4.org/syncutil"
+)
+
+var (
+	flagApiAddress = flag.String("address", internal.DefaultApiAddress, "Moov API address")
+	flagLocal      = flag.Bool("local", false, "Use local HTTP addresses")
+
+	flagThreshold = flag.Float64("threshold", 0.90, "Minimum match percentage required for blocking")
+
+	flagAllowedFile = flag.String("allowed-file", filepath.Join("test", "testdata", "allowed.txt"), "Filepath to file with names expected to be allowed")
+	flagBlockedFile = flag.String("blocked-file", filepath.Join("test", "testdata", "blocked.txt"), "Filepath to file with names expected to be blocked")
+
+	flagSdnType = flag.String("sdn-type", "individual", "sdnType query param")
+
+	flagRequestID = flag.String("request-id", "", "Override what is set for the X-Request-ID HTTP header")
+	flagUserID    = flag.String("user-id", "", "Override what is set for the X-User-ID HTTP header")
+
+	flagVerbose = flag.Bool("v", false, "Enable detailed logging")
+
+	flagWorkers = flag.Int("workers", runtime.NumCPU(), "How many tasks to run concurrently")
+)
+
+func main() {
+	flag.Parse()
+
+	log.SetFlags(log.Ldate | log.Ltime | log.LUTC | log.Lmicroseconds | log.Lshortfile)
+	log.Printf("Starting moov/ofaccheck %s", ofac.Version)
+
+	conf := internal.Config(*flagApiAddress, *flagLocal)
+	log.Printf("[INFO] using %s for address", conf.BasePath)
+
+	// Setup OFAC API client
+	api, ctx := moov.NewAPIClient(conf), context.TODO()
+
+	// Ping OFAC
+	if err := ping(ctx, api); err != nil {
+		log.Fatal("[FAILURE] ping OFAC")
+	} else {
+		log.Println("[SUCCESS] ping")
+	}
+
+	// Perform checks over the two incoming files
+	if path := *flagAllowedFile; path != "" {
+		names, err := readNames(path)
+		if err != nil {
+			log.Fatalf("[FAILURE] %v", err)
+		}
+		if n := checkNames(BlockUnexpected, names, *flagThreshold, api); n == Failure {
+			os.Exit(int(n))
+		}
+	}
+	if path := *flagBlockedFile; path != "" {
+		names, err := readNames(path)
+		if err != nil {
+			log.Fatalf("[FAILURE] %v", err)
+		}
+		if n := checkNames(BlockExpected, names, *flagThreshold, api); n == Failure {
+			os.Exit(int(n))
+		}
+	}
+}
+
+func ping(ctx context.Context, api *moov.APIClient) error {
+	resp, err := api.OFACApi.Ping(ctx)
+	if err != nil {
+		return err
+	}
+	resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return fmt.Errorf("ping error (stats code: %d): %v", resp.StatusCode, err)
+	}
+	return nil
+}
+
+type action int
+
+var (
+	BlockExpected   action = 1
+	BlockUnexpected action = 2
+)
+
+var (
+	Success int64 = 0
+	Failure int64 = 1
+)
+
+func checkNames(desc action, names []string, threshold float64, api *moov.APIClient) int64 {
+	var wg sync.WaitGroup
+	wg.Add(len(names))
+
+	var exitCode int64 // must be protected with atomic calls
+	markFailure := func() {
+		atomic.CompareAndSwapInt64(&exitCode, Success, Failure) // set Failure as exit code
+	}
+
+	workers := syncutil.NewGate(*flagWorkers)
+
+	for i := range names {
+		workers.Start()
+		go func(name string) {
+			defer workers.Done()
+			defer wg.Done()
+
+			if match, err := searchByName(api, name); err != nil {
+				markFailure()
+				log.Printf("[FATAL] problem searching for '%s': %v", name, err)
+			} else {
+				switch desc {
+				case BlockExpected:
+					if match < threshold {
+						markFailure()
+						log.Printf("[ERROR] '%s' wasn't blocked (match=%.2f)", name, match)
+					} else {
+						log.Printf("[INFO] blocked '%s'", name)
+					}
+				case BlockUnexpected:
+					if match > threshold {
+						markFailure()
+						log.Printf("[ERROR] '%s' was blocked (match=%.2f)", name, match)
+					} else {
+						if *flagVerbose {
+							log.Printf("[INFO] didn't block '%s'", name)
+						}
+					}
+				}
+			}
+		}(names[i])
+	}
+
+	wg.Wait() // block until all requests are finished
+
+	return exitCode
+}
+
+func readNames(path string) ([]string, error) {
+	fd, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("problem reading %s: %v", path, err)
+	}
+	defer fd.Close()
+
+	scanner := bufio.NewScanner(fd)
+
+	var names []string
+	for scanner.Scan() {
+		name := strings.TrimSpace(scanner.Text())
+		if strings.HasPrefix(name, "//") || strings.HasPrefix(name, "#") {
+			continue
+		}
+		names = append(names, name)
+	}
+	return names, nil
+}
+
+func searchByName(api *moov.APIClient, name string) (float64, error) {
+	opts := &moov.SearchOpts{
+		Limit:      optional.NewInt32(1),
+		Name:       optional.NewString(name),
+		SdnType:    optional.NewString(*flagSdnType),
+		XRequestID: optional.NewString(*flagRequestID),
+		XUserID:    optional.NewString(*flagUserID),
+	}
+
+	ctx, cancelFunc := context.WithTimeout(context.TODO(), 5*time.Second)
+	defer cancelFunc()
+
+	search, resp, err := api.OFACApi.Search(ctx, opts)
+	if err != nil {
+		return 0.0, fmt.Errorf("searchByName: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if len(search.SDNs) == 0 {
+		return 0.0, errors.New("no SDNs returned")
+	}
+	return float64(search.SDNs[0].Match), nil
+}

--- a/cmd/ofaccheck/main.go
+++ b/cmd/ofaccheck/main.go
@@ -2,11 +2,19 @@
 // Use of this source code is governed by an Apache License
 // license that can be found in the LICENSE file.
 
-// ofaccheck is a cli tool used for testing batches of names against the OFAC service.
+// ofaccheck is a cli tool used for testing batches of names against Moov's OFAC service.
 //
-// With no arguments the contaier runs tests against the production API.
+// With no arguments the contaier runs tests against the production API, but we strongly ask you
+// run ofaccheck against local instances of OFAC.
 //
-// TODO(adam): more docs
+// $ ofaccheck -allowed-file users.txt -blocked-file criminals.txt -threshold 0.99 -sdn-type individual -v
+// 2019/10/09 17:36:16.160025 main.go:61: Starting moov/ofaccheck v0.12.0-dev
+// 2019/10/09 17:36:16.160055 main.go:64: [INFO] using http://localhost:8084 for address
+// 2019/10/09 17:36:16.161818 main.go:73: [SUCCESS] ping
+// 2019/10/09 17:36:16.174108 main.go:156: [INFO] didn't block 'Husein HAZEM'
+// 2019/10/09 17:36:16.212986 main.go:148: [INFO] blocked 'Nicolas Ernesto MADURO GUERRA'
+// 2019/10/09 17:36:16.213423 main.go:146: [ERROR] 'Maria Alexandra PERDOMO' wasn't blocked (match=0.96)
+// exit status 1
 //
 // ofaccheck is not a stable tool. Please contact Moov developers if you intend to use this tool,
 // otherwise we might change the tool (or remove it) without notice.

--- a/makefile
+++ b/makefile
@@ -3,11 +3,14 @@ VERSION := $(shell grep -Eo '(v[0-9]+[\.][0-9]+[\.][0-9]+(-[a-zA-Z0-9]*)?)' vers
 
 .PHONY: build build-server build-examples docker release check
 
-build: check build-server build-ofactest build-examples
+build: check build-server build-ofaccheck build-ofactest build-examples
 	cd webui/ && npm install && npm run build && cd ../
 
 build-server:
 	CGO_ENABLED=1 go build -o ./bin/server github.com/moov-io/ofac/cmd/server
+
+build-ofaccheck:
+	CGO_ENABLED=0 go build -o ./bin/ofaccheck github.com/moov-io/ofac/cmd/ofaccheck
 
 build-ofactest:
 	CGO_ENABLED=0 go build -o ./bin/ofactest github.com/moov-io/ofac/cmd/ofactest

--- a/test/testdata/allowed.txt
+++ b/test/testdata/allowed.txt
@@ -1,0 +1,3 @@
+Amin Muhammed SHAR
+Husein HAZEM
+// Manuel Ricardo CRISTOPHER FIGUERA

--- a/test/testdata/blocked.txt
+++ b/test/testdata/blocked.txt
@@ -1,0 +1,5 @@
+Ali Wahib AL-ZAIN
+Hussein Hazem
+Maria Alexandra PERDOMO
+Nicolas Ernesto MADURO GUERRA
+Shari Amin Muhammad


### PR DESCRIPTION
```
ofaccheck is a cli tool used for testing batches of names against Moov's OFAC service.

With no arguments the contaier runs tests against the production API, but we strongly ask you
run ofaccheck against local instances of OFAC.

$ ofaccheck -allowed-file users.txt -blocked-file criminals.txt -threshold 0.99 -sdn-type individual -v
2019/10/09 17:36:16.160025 main.go:61: Starting moov/ofaccheck v0.12.0-dev
2019/10/09 17:36:16.160055 main.go:64: [INFO] using http://localhost:8084 for address
2019/10/09 17:36:16.161818 main.go:73: [SUCCESS] ping
2019/10/09 17:36:16.174108 main.go:156: [INFO] didn't block 'Husein HAZEM'
2019/10/09 17:36:16.212986 main.go:148: [INFO] blocked 'Nicolas Ernesto MADURO GUERRA'
2019/10/09 17:36:16.213423 main.go:146: [ERROR] 'Maria Alexandra PERDOMO' wasn't blocked (match=0.96)
exit status 1

ofaccheck is not a stable tool. Please contact Moov developers if you intend to use this tool,
otherwise we might change the tool (or remove it) without notice.
```